### PR TITLE
Remove Makefile and replace make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-SHELL := /bin/bash -euxo pipefail
-.PHONY: docs
-docs:
-	uv run --extra=dev sphinx-build -M html docs/source docs/build -W
-
-.PHONY: open-docs
-open-docs:
-	python -c 'import os, webbrowser; webbrowser.open("file://" + os.path.abspath("docs/build/html/index.html"))'

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -64,8 +64,8 @@ Run the following commands to build and view documentation locally:
 
 .. code-block:: console
 
-   $ make docs
-   $ make open-docs
+   $ uv run --extra=dev sphinx-build -M html docs/source docs/build -W
+   $ python -c 'import os, webbrowser; webbrowser.open("file://" + os.path.abspath("docs/build/html/index.html"))'
 
 Continuous integration
 ----------------------


### PR DESCRIPTION
## Summary
- Remove Makefile
- Replace `make docs` and `make open-docs` commands with direct equivalents in documentation

## Changes
- Deleted Makefile
- Updated docs/source/contributing.rst to use direct sphinx-build and python commands

## Test plan
- Documentation builds correctly with the new commands
- All existing functionality is preserved