### PR TITLE
Add validation for gha-find-replace actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
           echo "underline=${underline}" >> "$GITHUB_OUTPUT"
 
       - name: Update changelog
+        id: update_changelog
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
@@ -63,6 +64,12 @@ jobs:
           include: CHANGELOG.rst
           regex: false
 
+      - name: Check Update changelog was modified
+        run: |
+          if [ "${{ steps.update_changelog.outputs.modifiedFiles }}" = "0" ]; then
+            echo "Error: No files were modified when updating changelog"
+            exit 1
+          fi
       - uses: stefanzweifel/git-auto-commit-action@v7
         id: commit
         with:


### PR DESCRIPTION
## Summary
- Add validation for gha-find-replace actions
- Fail the workflow if no files are modified during file updates
- This prevents silent failures in the release process

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add validation to the release workflow to fail if the changelog update modifies no files.
> 
> - **CI (release workflow)** in `.github/workflows/release.yml`:
>   - Add `id: update_changelog` to the changelog update step for output access.
>   - New validation step to fail the workflow if `gha-find-replace` modifies 0 files (ensuring changelog actually updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af3d68217fb3c98fc1ea0c2c00be3d71da1df79a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->