### PR TITLE
Add ty to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,8 @@ ci:
     - pyright
     - pyright-docs
     - pyright-verifytypes
+    - ty
+    - ty-docs
     - pyroma
     - ruff-check-fix
     - ruff-check-fix-docs
@@ -339,6 +341,24 @@ repos:
         language: python
         pass_filenames: false
         types_or: [python]
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty
+        name: ty
+        stages: [pre-push]
+        entry: uv run --extra=dev ty check
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty-docs
+        name: ty-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="ty check"
+        language: python
+        types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
 
       - id: yamlfix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ optional-dependencies.dev = [
     "sphinx-substitution-extensions==2025.11.17",
     "sphinxcontrib-spelling==8.0.2",
     "sybil==9.3.0",
+    "ty==0.0.1a34",
     "types-requests==2.32.4.20250913",
     "vulture==2.14",
     "vws-python-mock==2025.3.10.1",


### PR DESCRIPTION
Add ty and ty-docs hooks to pre-commit configuration.

This adds type checking with ty, following the pattern established in other repositories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ty type checks (and docs runner) to pre-commit and includes ty in dev dependencies.
> 
> - **Pre-commit**:
>   - Add `ty` and `ty-docs` hooks (stage: `pre-push`) invoking `uv run --extra=dev ty check` and via `doccmd`.
>   - Extend CI `skip` list to include `ty` and `ty-docs`.
> - **Dependencies**:
>   - Add `ty==0.0.1a34` to `optional-dependencies.dev` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 394cc018b13c3a1bdafd296e816dde6919646c45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->