### PR TITLE
Add Claude Code LSP plugin for Python

### DIFF
--- a/.claude/plugins/pyright-lsp/.claude-plugin/plugin.json
+++ b/.claude/plugins/pyright-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "pyright-lsp",
+  "description": "Python language server using Pyright",
+  "version": "1.0.0"
+}

--- a/.claude/plugins/pyright-lsp/.lsp.json
+++ b/.claude/plugins/pyright-lsp/.lsp.json
@@ -1,0 +1,11 @@
+{
+  "python": {
+    "command": "pyright-langserver",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".py": "python",
+      ".pyi": "python"
+    },
+    "transport": "stdio"
+  }
+}


### PR DESCRIPTION
## Summary
- Add pyright LSP plugin for Claude Code at project scope
- Located in `.claude/plugins/pyright-lsp/`

## Configuration
- Plugin uses pyright-langserver for Python language support
- Configured for `.py` and `.pyi` files

## Test plan
- Ensure pyright-langserver is installed
- Set `ENABLE_LSP_TOOL=1` environment variable
- Start Claude Code in the repository

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Python LSP support via Pyright at the project level.
> 
> - Adds `plugin.json` defining the `pyright-lsp` plugin in `.claude/plugins/pyright-lsp/`
> - Adds `.lsp.json` configuring `pyright-langserver` over `--stdio` and mapping `.py`/`.pyi` to `python`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e84b930ce01ab77ab929c33cc5c87d38ced8b8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->