### PR TITLE
Make prettier printWidth more compatible with yamlfix

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,8 @@
     {
       "files": ["*.yaml", "*.yml"],
       "options": {
-        "singleQuote": true
+        "singleQuote": true,
+        "printWidth": 100
       }
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Prettier config for YAML formatting.
> 
> - Adds `printWidth: 100` to the YAML/YML override in `.prettierrc`
> - No application code changes; formatting behavior only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bca8178e917fc97c4c3930fd3686be3ab93591f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->