### PR TITLE
prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
       "files": ["*.yaml", "*.yml"],
       "options": {
         "singleQuote": true,
-        "printWidth": 100",
+        "printWidth": 100,
         "printWidth": 100
       }
     }


### PR DESCRIPTION
- **Make prettier printWidth more compatible with yamlfix**
- **Make prettier more compatible with yamlfix**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts Prettier configuration for YAML files.
> 
> - In `.prettierrc`, YAML overrides now include a duplicated `printWidth: 100` entry alongside existing `singleQuote: true`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63942af74d3513bc9c33ea54fb688fb10a052537. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->