### PR TITLE
Remove --example-workers 0 due to mypy bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 ---
 fail_fast: true
 
+# We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
@@ -122,8 +124,8 @@ repos:
 
       - id: shellcheck-docs
         name: shellcheck-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=shell
-          --language=console --command="shellcheck --shell=bash"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=shell --language=console
+          --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -158,8 +160,7 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -184,8 +185,7 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="pyright"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyright"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -201,8 +201,7 @@ repos:
 
       - id: vulture-docs
         name: vulture docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="vulture"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="vulture"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -235,8 +234,7 @@ repos:
 
       - id: pylint-docs
         name: pylint-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="pylint"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pylint"
         language: python
         stages: [manual]
         types_or: [markdown, rst]
@@ -293,8 +291,7 @@ repos:
 
       - id: interrogate-docs
         name: interrogate docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="interrogate"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="interrogate"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -358,8 +355,8 @@ repos:
       - id: ty-docs
         name: ty-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="ty check"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="ty
+          check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -401,8 +398,8 @@ repos:
       - id: pyrefly-docs
         name: pyrefly-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="pyrefly check"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyrefly
+          check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
This removes `--example-workers 0` from the pre-commit config due to a mypy race condition bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts pre-commit configuration to avoid a mypy race condition.
> 
> - Updates `.pre-commit-config.yaml` to remove `--example-workers 0` from `doccmd` invocations across `*-docs` hooks (e.g., `shellcheck-docs`, `mypy-docs`, `pyright-docs`, `vulture-docs`, `pylint-docs`, `interrogate-docs`, `ty-docs`, `pyrefly-docs`)
> - Adds an explanatory comment referencing https://github.com/python/mypy/issues/18283
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 099a85381d6547554c43b99c1cdfa2bb41b35c7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->