### PR TITLE
Fix: Remove --example-workers 0 only from mypy-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,6 +155,7 @@ repos:
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
 
+      # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]


### PR DESCRIPTION
The previous PR incorrectly removed `--example-workers 0` from all hooks.

This PR reverts that and correctly removes it only from the `mypy-docs` hook, which is the one affected by the mypy bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns pre-commit docs hooks with intended parallelism settings while exempting mypy.
> 
> - Re-adds `--example-workers 0` to `shellcheck-docs`, `pyright-docs`, `vulture-docs`, `pylint-docs`, `interrogate-docs`, `ty-docs`, and `pyrefly-docs`
> - Keeps `mypy-docs` without `--example-workers 0`; adds clarifying comment referencing mypy issue
> - Configuration-only change in `.pre-commit-config.yaml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a9c9f60296dc392004d5d8fdbee2f2ed6d2d094. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->