### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = [
     "version",
@@ -311,7 +312,7 @@ pep621_dev_dependency_groups = [
 [tool.pyproject-fmt]
 indent = 4
 keep_full_version = true
-max_supported_python = "3.13"
+max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
 


### PR DESCRIPTION
Add Python 3.14 to the test matrix and classifiers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Declares and tests Python 3.14 support.
> 
> - Expands GitHub Actions matrix in `.github/workflows/ci.yml` to `python-version: ['3.13', '3.14']` on Ubuntu and Windows
> - Adds `"Programming Language :: Python :: 3.14"` classifier and updates `tool.pyproject-fmt.max_supported_python` to `"3.14"` in `pyproject.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90cd53bb3a690f83d6c1edc3e42db6b4dc3f61a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->