### PR TITLE
Bump pyproject-fmt to 2.14.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ optional-dependencies.dev = [
     "pygments==2.19.2",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
-    "pyproject-fmt==2.14.0",
+    "pyproject-fmt==2.14.2",
     "pyrefly==0.51.1",
     "pyright==1.1.408",
     "pyroma==5.0.1",
@@ -62,6 +62,10 @@ optional-dependencies.dev = [
     "pytest-cov==7.0.0",
     "pyyaml==6.0.3",
     "ruff==0.15.0",
+    # We add shellcheck-py not only for shell scripts and shell code blocks,
+    # but also because having it installed means that ``actionlint-py`` will
+    # use it to lint shell commands in GitHub workflow files.
+    "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
     "sphinx==9.1.0",
     "sphinx-copybutton==0.5.2",
@@ -75,10 +79,6 @@ optional-dependencies.dev = [
     "vulture==2.14",
     "vws-python-mock==2025.3.10.1",
     "vws-test-fixtures==2023.3.5",
-    # We add shellcheck-py not only for shell scripts and shell code blocks,
-    # but also because having it installed means that ``actionlint-py`` will
-    # use it to lint shell commands in GitHub workflow files.
-    "shellcheck-py==0.11.0.1",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",
 ]
@@ -112,17 +112,17 @@ lint.select = [
     "ALL",
 ]
 lint.ignore = [
+    # Ruff warns that this conflicts with the formatter.
+    "COM812",
     # Allow our chosen docstring line-style - pydocstringformatter handles formatting
     # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
     "D205",
+    "D212",
+    # Ruff warns that this conflicts with the formatter.
+    "ISC001",
     # Ignore 'too-many-*' errors as they seem to get in the way more than
     # helping.
     "PLR0913",
-    # Ruff warns that this conflicts with the formatter.
-    "COM812",
-    # Ruff warns that this conflicts with the formatter.
-    "ISC001",
-    "D212",
 ]
 lint.per-file-ignores."doccmd_*.py" = [
     # Allow asserts in docs.


### PR DESCRIPTION
Bump pyproject-fmt from 2.14.0 to 2.14.2 and re-format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates a dev dependency and adjusts config formatting/comments; no runtime code paths change.
> 
> **Overview**
> Updates dev tooling by bumping `pyproject-fmt` from `2.14.0` to `2.14.2`.
> 
> Reformats parts of `pyproject.toml`, including moving the `shellcheck-py` dev dependency comment/entry and reordering `ruff` `lint.ignore` entries with clearer per-ignore comments (no rule changes beyond ordering/comments).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28780e38e30338b74a5bed80b1221ff6157420ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->