### PR TITLE
Matrix lint workflow by hook stage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         python-version: ['3.13']
         platform: [ubuntu-latest, windows-latest]
+        hook-stage: [pre-commit, pre-push, manual]
 
     runs-on: ${{ matrix.platform }}
 
@@ -37,10 +38,8 @@ jobs:
         # Use bash to ensure the step fails if any command fails.
         # PowerShell does not fail on intermediate command failures by default.
         shell: bash
-        run: |
-          uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
-          uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose
-          uv run --extra=dev prek run --all-files --hook-stage manual --verbose
+        run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
+          --verbose
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Refactor the lint workflow to parallelize hook stage execution by adding `hook-stage` to the build matrix. This runs all three hook stages (pre-commit, pre-push, manual) in parallel instead of sequentially.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only refactor that changes CI job fan-out and log grouping but not the lint commands themselves; primary risk is increased CI load or matrix misconfiguration.
> 
> **Overview**
> **Parallelizes CI linting by hook stage.** The `lint.yml` workflow adds `hook-stage` (`pre-commit`, `pre-push`, `manual`) to the build matrix so each stage runs as its own matrix job across both Ubuntu and Windows.
> 
> The `Lint` step is simplified from three sequential `prek run` invocations to a single command parameterized by `${{ matrix.hook-stage }}`, improving visibility and reducing total wall-clock time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74763f3b207b4e6c206b55bf56907d7eefcb2e43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->