### PR TITLE
Bump vws-python-mock from 2025.3.10.1 to 2026.2.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ optional-dependencies.dev = [
     "ty==0.0.16",
     "types-requests==2.32.4.20260107",
     "vulture==2.14",
-    "vws-python-mock==2025.3.10.1",
+    "vws-python-mock==2026.2.15",
     "vws-test-fixtures==2023.3.5",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",


### PR DESCRIPTION
## Summary

Bumps vws-python-mock from 2025.3.10.1 to 2026.2.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates a pinned dev/test dependency version; no runtime code changes.
> 
> **Overview**
> Bumps the dev dependency `vws-python-mock` in `pyproject.toml` from `2025.3.10.1` to `2026.2.15`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16c4604eb208167feeffe1ebfdcc8dd30e2bc2b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->