### PR TITLE
Bump vws-python-mock to 2026.2.15.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ optional-dependencies.dev = [
     "ty==0.0.16",
     "types-requests==2.32.4.20260107",
     "vulture==2.14",
-    "vws-python-mock==2026.2.15",
+    "vws-python-mock==2026.2.15.4",
     "vws-test-fixtures==2023.3.5",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",


### PR DESCRIPTION
Bumps vws-python-mock from 2026.2.15 to 2026.2.15.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes a pinned development/test dependency version; no runtime code changes.
> 
> **Overview**
> Updates the dev dependency pin for `vws-python-mock` in `pyproject.toml` from `2026.2.15` to `2026.2.15.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8b8800f4c19b1d7c2d10063bd2e398154b296ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->