### PR TITLE
Add pyrefly non-exhaustive match as error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,6 +302,9 @@ plugins = [
     "mypy_strict_kwargs",
 ]
 
+[tool.pyrefly]
+errors.non-exhaustive-match = "error"
+
 [tool.pyright]
 enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
@@ -376,6 +379,3 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[tool.pyrefly]
-errors.non-exhaustive-match = "error"


### PR DESCRIPTION
Adds \ to \ in project \ files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that tightens static analysis; may cause CI failures until code is updated to satisfy the stricter rule.
> 
> **Overview**
> Adds a `pyrefly` configuration block to `pyproject.toml` that upgrades `non-exhaustive-match` findings to **errors**, making incomplete match handling fail the type-check/lint step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26b9256dcaca967567f75b28b0720ed22a03cbde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->