### PR TITLE
Use CPU-only PyTorch index to speed up dev installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,11 @@ optional-dependencies.dev = [
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
     "sybil==9.3.0",
+    # Listed explicitly (despite being transitive via vws-python-mock) so that
+    # [tool.uv.sources] can redirect to the CPU-only PyTorch index.
+    # See: https://vws-python.github.io/vws-python-mock/installation.html#faster-installation
+    "torch>=2.5.1",
+    "torchvision>=0.20.1",
     "ty==0.0.17",
     "types-requests==2.32.4.20260107",
     "vulture==2.14",
@@ -105,6 +110,11 @@ bdist_wheel.universal = true
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
+
+[tool.uv]
+sources.torch = { index = "pytorch-cpu" }
+sources.torchvision = { index = "pytorch-cpu" }
+index = [ { name = "pytorch-cpu", url = "https://download.pytorch.org/whl/cpu", explicit = true } ]
 
 [tool.ruff]
 line-length = 79
@@ -276,6 +286,13 @@ ignore = [
 pep621_dev_dependency_groups = [
     "dev",
     "release",
+]
+# torch and torchvision are listed explicitly in dev deps to allow
+# [tool.uv.sources] to redirect them to the CPU-only PyTorch index,
+# but they are not directly imported in the vws-python source code.
+per_rule_ignores.DEP002 = [
+    "torch",
+    "torchvision",
 ]
 
 [tool.pyproject-fmt]


### PR DESCRIPTION
## Summary

- `vws-python-mock` (a dev dependency) transitively requires `torch` and `torchvision`
- By default, `uv` resolves these from PyPI which provides CUDA-enabled wheels on Linux (~916 MB for `torch` alone)
- This PR follows the [faster installation guide](https://vws-python.github.io/vws-python-mock/installation.html#faster-installation) to redirect `torch` and `torchvision` to the CPU-only PyTorch index

## Does it actually make installation faster?

Yes — tested empirically:

| Package | CUDA wheel (PyPI) | CPU-only wheel | Saving |
|---------|------------------|----------------|--------|
| `torch` (Linux, cp313) | 916 MB | 189 MB | **727 MB** |
| `torchvision` (Linux, cp313) | 8 MB | 2 MB | 6 MB |

**~733 MB total reduction** per cold-cache install on Linux CI runners.

## Implementation notes

`[tool.uv.sources]` only applies to direct dependencies (not transitive ones), so `torch` and `torchvision` must be listed explicitly in `optional-dependencies.dev` for the source override to take effect. A `deptry` ignore is added since these packages are not directly imported in the `vws-python` source code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts development dependency resolution and linting configuration; no runtime or production code paths are affected.
> 
> **Overview**
> Speeds up dev installs by ensuring `uv` resolves `torch`/`torchvision` from the CPU-only PyTorch wheel index instead of large default Linux CUDA wheels.
> 
> This makes `torch` and `torchvision` explicit `dev` dependencies (even though they’re transitive via `vws-python-mock`) and configures `[tool.uv]` source/index overrides to point to `https://download.pytorch.org/whl/cpu`. `deptry` is updated to ignore `DEP002` for these packages since they aren’t imported directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a828118f94531947b59c69e902ecdcac1d703a00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->