### PR TITLE
Bump vws-python-mock to 2026.2.18.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ optional-dependencies.dev = [
     "ty==0.0.17",
     "types-requests==2.32.4.20260107",
     "vulture==2.14",
-    "vws-python-mock==2026.2.18",
+    "vws-python-mock==2026.2.18.2",
     "vws-test-fixtures==2023.3.5",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",


### PR DESCRIPTION
Bump vws-python-mock to the latest version 2026.2.18.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change limited to the development/test dependency set; no production runtime code is modified.
> 
> **Overview**
> Bumps the `dev` extra dependency `vws-python-mock` from `2026.2.18` to `2026.2.18.2` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a55c113afb7772ef96722749c325e55e1f26549d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->