### PR TITLE
Bump vws-python-mock to 2026.2.21

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 from beartype import beartype
 from mock_vws import MockVWS
-from mock_vws.database import VuforiaDatabase
+from mock_vws.database import CloudDatabase
 from sybil import Sybil
 from sybil.parsers.rest import (
     ClearNamespaceParser,
@@ -53,7 +53,7 @@ def fixture_mock_vws(
     client_access_key = uuid.uuid4().hex
     client_secret_key = uuid.uuid4().hex
 
-    database = VuforiaDatabase(
+    database = CloudDatabase(
         server_access_key=server_access_key,
         server_secret_key=server_secret_key,
         client_access_key=client_access_key,
@@ -66,7 +66,7 @@ def fixture_mock_vws(
     monkeypatch.setenv(name="VWS_CLIENT_SECRET_KEY", value=client_secret_key)
     # We use a low processing time so that tests run quickly.
     with MockVWS(processing_time_seconds=0.2) as mock:
-        mock.add_database(database=database)
+        mock.add_cloud_database(cloud_database=database)
         yield
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -78,13 +78,13 @@ To write unit tests for code which uses this library, without using your Vuforia
     import pathlib
 
     from mock_vws import MockVWS
-    from mock_vws.database import VuforiaDatabase
+    from mock_vws.database import CloudDatabase
 
     from vws import VWS, CloudRecoService
 
     with MockVWS() as mock:
-        database = VuforiaDatabase()
-        mock.add_database(database=database)
+        database = CloudDatabase()
+        mock.add_cloud_database(cloud_database=database)
         vws_client = VWS(
             server_access_key=database.server_access_key,
             server_secret_key=database.server_secret_key,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ optional-dependencies.dev = [
     "ty==0.0.17",
     "types-requests==2.32.4.20260107",
     "vulture==2.14",
-    "vws-python-mock==2026.2.18.2",
+    "vws-python-mock==2026.2.21",
     "vws-test-fixtures==2023.3.5",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,23 +7,23 @@ from typing import BinaryIO, Literal
 
 import pytest
 from mock_vws import MockVWS
-from mock_vws.database import VuforiaDatabase
+from mock_vws.database import CloudDatabase
 
 from vws import VWS, CloudRecoService
 
 
 @pytest.fixture(name="_mock_database")
-def fixture_mock_database() -> Generator[VuforiaDatabase]:
-    """Yield a mock ``VuforiaDatabase``."""
+def fixture_mock_database() -> Generator[CloudDatabase]:
+    """Yield a mock ``CloudDatabase``."""
     # We use a low processing time so that tests run quickly.
     with MockVWS(processing_time_seconds=0.2) as mock:
-        database = VuforiaDatabase()
-        mock.add_database(database=database)
+        database = CloudDatabase()
+        mock.add_cloud_database(cloud_database=database)
         yield database
 
 
 @pytest.fixture
-def vws_client(_mock_database: VuforiaDatabase) -> VWS:
+def vws_client(_mock_database: CloudDatabase) -> VWS:
     """A VWS client which connects to a mock database."""
     return VWS(
         server_access_key=_mock_database.server_access_key,
@@ -32,7 +32,7 @@ def vws_client(_mock_database: VuforiaDatabase) -> VWS:
 
 
 @pytest.fixture
-def cloud_reco_client(_mock_database: VuforiaDatabase) -> CloudRecoService:
+def cloud_reco_client(_mock_database: CloudDatabase) -> CloudRecoService:
     """A ``CloudRecoService`` client which connects to a mock database."""
     return CloudRecoService(
         client_access_key=_mock_database.client_access_key,

--- a/tests/test_cloud_reco_exceptions.py
+++ b/tests/test_cloud_reco_exceptions.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 
 import pytest
 from mock_vws import MockVWS
-from mock_vws.database import VuforiaDatabase
+from mock_vws.database import CloudDatabase
 from mock_vws.states import States
 
 from vws import CloudRecoService
@@ -85,13 +85,13 @@ def test_authentication_failure(
     key
     exists but the client secret key is incorrect.
     """
-    database = VuforiaDatabase()
+    database = CloudDatabase()
     cloud_reco_client = CloudRecoService(
         client_access_key=database.client_access_key,
         client_secret_key=uuid.uuid4().hex,
     )
     with MockVWS() as mock:
-        mock.add_database(database=database)
+        mock.add_cloud_database(cloud_database=database)
 
         with pytest.raises(
             expected_exception=AuthenticationFailureError
@@ -108,9 +108,9 @@ def test_inactive_project(
     An ``InactiveProject`` exception is raised when querying an inactive
     database.
     """
-    database = VuforiaDatabase(state=States.PROJECT_INACTIVE)
+    database = CloudDatabase(state=States.PROJECT_INACTIVE)
     with MockVWS() as mock:
-        mock.add_database(database=database)
+        mock.add_cloud_database(cloud_database=database)
         cloud_reco_client = CloudRecoService(
             client_access_key=database.client_access_key,
             client_secret_key=database.client_secret_key,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -9,7 +9,7 @@ import pytest
 import requests
 from freezegun import freeze_time
 from mock_vws import MockVWS
-from mock_vws.database import VuforiaDatabase
+from mock_vws.database import CloudDatabase
 
 from vws import VWS, CloudRecoService
 from vws.include_target_data import CloudRecoIncludeTargetData
@@ -75,8 +75,8 @@ class TestDefaultRequestTimeout:
                 )[1],
             ) as mock,
         ):
-            database = VuforiaDatabase()
-            mock.add_database(database=database)
+            database = CloudDatabase()
+            mock.add_cloud_database(cloud_database=database)
             cloud_reco_client = CloudRecoService(
                 client_access_key=database.client_access_key,
                 client_secret_key=database.client_secret_key,
@@ -129,8 +129,8 @@ class TestCustomRequestTimeout:
                 )[1],
             ) as mock,
         ):
-            database = VuforiaDatabase()
-            mock.add_database(database=database)
+            database = CloudDatabase()
+            mock.add_cloud_database(cloud_database=database)
             cloud_reco_client = CloudRecoService(
                 client_access_key=database.client_access_key,
                 client_secret_key=database.client_secret_key,
@@ -160,8 +160,8 @@ class TestCustomBaseVWQURL:
         """
         base_vwq_url = "http://example.com"
         with MockVWS(base_vwq_url=base_vwq_url) as mock:
-            database = VuforiaDatabase()
-            mock.add_database(database=database)
+            database = CloudDatabase()
+            mock.add_cloud_database(cloud_database=database)
             vws_client = VWS(
                 server_access_key=database.server_access_key,
                 server_secret_key=database.server_secret_key,

--- a/tests/test_vws.py
+++ b/tests/test_vws.py
@@ -11,7 +11,7 @@ import pytest
 import requests
 from freezegun import freeze_time
 from mock_vws import MockVWS
-from mock_vws.database import VuforiaDatabase
+from mock_vws.database import CloudDatabase
 
 from vws import VWS, CloudRecoService
 from vws.exceptions.custom_exceptions import TargetProcessingTimeoutError
@@ -122,8 +122,8 @@ class TestDefaultRequestTimeout:
                 )[1],
             ) as mock,
         ):
-            database = VuforiaDatabase()
-            mock.add_database(database=database)
+            database = CloudDatabase()
+            mock.add_cloud_database(cloud_database=database)
             vws_client = VWS(
                 server_access_key=database.server_access_key,
                 server_secret_key=database.server_secret_key,
@@ -187,8 +187,8 @@ class TestCustomRequestTimeout:
                 )[1],
             ) as mock,
         ):
-            database = VuforiaDatabase()
-            mock.add_database(database=database)
+            database = CloudDatabase()
+            mock.add_cloud_database(cloud_database=database)
             vws_client = VWS(
                 server_access_key=database.server_access_key,
                 server_secret_key=database.server_secret_key,
@@ -228,8 +228,8 @@ class TestCustomBaseVWSURL:
         """
         base_vws_url = "http://example.com"
         with MockVWS(base_vws_url=base_vws_url) as mock:
-            database = VuforiaDatabase()
-            mock.add_database(database=database)
+            database = CloudDatabase()
+            mock.add_cloud_database(cloud_database=database)
             vws_client = VWS(
                 server_access_key=database.server_access_key,
                 server_secret_key=database.server_secret_key,
@@ -489,8 +489,8 @@ class TestWaitForTargetProcessed:
     ) -> None:
         """By default, 0.2 seconds are waited between polling requests."""
         with MockVWS(processing_time_seconds=0.5) as mock:
-            database = VuforiaDatabase()
-            mock.add_database(database=database)
+            database = CloudDatabase()
+            mock.add_cloud_database(cloud_database=database)
             vws_client = VWS(
                 server_access_key=database.server_access_key,
                 server_secret_key=database.server_secret_key,
@@ -541,8 +541,8 @@ class TestWaitForTargetProcessed:
         requests.
         """
         with MockVWS(processing_time_seconds=0.5) as mock:
-            database = VuforiaDatabase()
-            mock.add_database(database=database)
+            database = CloudDatabase()
+            mock.add_cloud_database(cloud_database=database)
             vws_client = VWS(
                 server_access_key=database.server_access_key,
                 server_secret_key=database.server_secret_key,
@@ -589,8 +589,8 @@ class TestWaitForTargetProcessed:
     def test_custom_timeout(image: io.BytesIO | BinaryIO) -> None:
         """It is possible to set a maximum timeout."""
         with MockVWS(processing_time_seconds=0.5) as mock:
-            database = VuforiaDatabase()
-            mock.add_database(database=database)
+            database = CloudDatabase()
+            mock.add_cloud_database(cloud_database=database)
             vws_client = VWS(
                 server_access_key=database.server_access_key,
                 server_secret_key=database.server_secret_key,

--- a/tests/test_vws_exceptions.py
+++ b/tests/test_vws_exceptions.py
@@ -7,7 +7,7 @@ from http import HTTPStatus
 import pytest
 from freezegun import freeze_time
 from mock_vws import MockVWS
-from mock_vws.database import VuforiaDatabase
+from mock_vws.database import CloudDatabase
 from mock_vws.states import States
 
 from vws import VWS
@@ -175,9 +175,9 @@ def test_project_inactive(
     inactive
     database.
     """
-    database = VuforiaDatabase(state=States.PROJECT_INACTIVE)
+    database = CloudDatabase(state=States.PROJECT_INACTIVE)
     with MockVWS() as mock:
-        mock.add_database(database=database)
+        mock.add_cloud_database(cloud_database=database)
         vws_client = VWS(
             server_access_key=database.server_access_key,
             server_secret_key=database.server_secret_key,
@@ -286,7 +286,7 @@ def test_authentication_failure(
     exists but the server secret key is incorrect, or when a client key is
     incorrect.
     """
-    database = VuforiaDatabase()
+    database = CloudDatabase()
 
     vws_client = VWS(
         server_access_key=database.server_access_key,
@@ -294,7 +294,7 @@ def test_authentication_failure(
     )
 
     with MockVWS() as mock:
-        mock.add_database(database=database)
+        mock.add_cloud_database(cloud_database=database)
 
         with pytest.raises(
             expected_exception=AuthenticationFailureError


### PR DESCRIPTION
## Summary

- Bumps `vws-python-mock` from `2026.2.18.2` to `2026.2.21`
- Updates `VuforiaDatabase` → `CloudDatabase` throughout tests and docs
- Updates `add_database(database=...)` → `add_cloud_database(cloud_database=...)` throughout tests and docs

## Test plan

- [x] `uv run --all-extras pytest` — 178 passed
- [x] All pre-commit hooks passed (mypy, pyright, ruff, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily dependency bump and mechanical test/docs refactor; main risk is CI breakage if the new mock API behaves differently, but production code paths are untouched.
> 
> **Overview**
> Bumps `vws-python-mock` from `2026.2.18.2` to `2026.2.21`.
> 
> Updates documentation and the full test suite to use `CloudDatabase` instead of `VuforiaDatabase`, and switches mock setup calls from `add_database(database=...)` to `add_cloud_database(cloud_database=...)` (including fixture type hints and docstrings) to match the new mock API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3a6a13822a7117aef9224019f5e138a580d1cc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->