### PR TITLE
Enforce keyword-only arguments

### DIFF
--- a/src/vws/query.py
+++ b/src/vws/query.py
@@ -46,6 +46,7 @@ class CloudRecoService:
 
     def __init__(
         self,
+        *,
         client_access_key: str,
         client_secret_key: str,
         base_vwq_url: str = "https://cloudreco.vuforia.com",
@@ -68,6 +69,7 @@ class CloudRecoService:
 
     def query(
         self,
+        *,
         image: _ImageType,
         max_num_results: int = 1,
         include_target_data: CloudRecoIncludeTargetData = (

--- a/src/vws/vws.py
+++ b/src/vws/vws.py
@@ -63,6 +63,7 @@ class VWS:
 
     def __init__(
         self,
+        *,
         server_access_key: str,
         server_secret_key: str,
         base_vws_url: str = "https://vws.vuforia.com",
@@ -171,11 +172,11 @@ class VWS:
 
     def add_target(
         self,
+        *,
         name: str,
         width: float,
         image: _ImageType,
         application_metadata: str | None,
-        *,
         active_flag: bool,
     ) -> str:
         """Add a target to a Vuforia Web Services database.
@@ -302,6 +303,7 @@ class VWS:
 
     def wait_for_target_processed(
         self,
+        *,
         target_id: str,
         seconds_between_requests: float = 0.2,
         timeout_seconds: float = 60 * 5,


### PR DESCRIPTION
## Summary
- Add `*` separator to enforce keyword-only arguments in `CloudRecoService.__init__`, `CloudRecoService.query`, `VWS.__init__`, `VWS.add_target`, and `VWS.wait_for_target_processed`
- All existing call sites already use keyword arguments, so no caller updates were needed

## Test plan
- [ ] Run existing test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signature-only change that should be low risk if downstream callers already use keyword args; risk is limited to external users calling these methods positionally.
> 
> **Overview**
> Enforces keyword-only arguments by adding `*` separators to `CloudRecoService.__init__`/`query` and `VWS.__init__`/`add_target`/`wait_for_target_processed`, preventing positional calls for these public APIs.
> 
> This is an API-signature tightening change only; runtime behavior is otherwise unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0cf4c1a3905953a04ae8f5ebfa1dc371ffa2b9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->