### PR TITLE
Use native pytest TOML configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,8 +301,8 @@ keep_full_version = true
 max_supported_python = "3.14"
 
 [tool.pytest]
-ini_options.xfail_strict = true
-ini_options.log_cli = true
+xfail_strict = true
+log_cli = true
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION
## Summary
- Remove `ini_options.` prefix from pytest configuration keys under `[tool.pytest]`
- Uses the native TOML configuration format supported since pytest 9.0
- See: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change limited to pytest settings; risk is mainly that older pytest versions may not recognize the new TOML keys.
> 
> **Overview**
> Switches `pyproject.toml` pytest configuration to pytest 9’s native TOML keys by removing the `ini_options.` prefix (e.g., `xfail_strict` and `log_cli`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b44e2522c7596476a77070f5b033b4ba37ba35c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->