### PR TITLE
Use keyword-only parameters in tests

### DIFF
--- a/tests/test_cloud_reco_exceptions.py
+++ b/tests/test_cloud_reco_exceptions.py
@@ -24,6 +24,7 @@ from vws.exceptions.custom_exceptions import (
 
 
 def test_too_many_max_results(
+    *,
     cloud_reco_client: CloudRecoService,
     high_quality_image: io.BytesIO,
 ) -> None:
@@ -45,6 +46,7 @@ def test_too_many_max_results(
 
 
 def test_image_too_large(
+    *,
     cloud_reco_client: CloudRecoService,
     png_too_large: io.BytesIO | io.BufferedRandom,
 ) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -20,6 +20,7 @@ class TestQuery:
 
     @staticmethod
     def test_no_matches(
+        *,
         cloud_reco_client: CloudRecoService,
         image: io.BytesIO | BinaryIO,
     ) -> None:
@@ -29,6 +30,7 @@ class TestQuery:
 
     @staticmethod
     def test_match(
+        *,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
         image: io.BytesIO | BinaryIO,
@@ -55,8 +57,8 @@ class TestDefaultRequestTimeout:
         argvalues=[(29, False), (31, True)],
     )
     def test_default_timeout(
-        image: io.BytesIO | BinaryIO,
         *,
+        image: io.BytesIO | BinaryIO,
         response_delay_seconds: int,
         expect_timeout: bool,
     ) -> None:
@@ -110,8 +112,8 @@ class TestCustomRequestTimeout:
         ],
     )
     def test_custom_timeout(
-        image: io.BytesIO | BinaryIO,
         *,
+        image: io.BytesIO | BinaryIO,
         custom_timeout: float | tuple[float, float],
         response_delay_seconds: float,
         expect_timeout: bool,
@@ -194,6 +196,7 @@ class TestMaxNumResults:
 
     @staticmethod
     def test_default(
+        *,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
         image: io.BytesIO | BinaryIO,
@@ -220,6 +223,7 @@ class TestMaxNumResults:
 
     @staticmethod
     def test_custom(
+        *,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
         image: io.BytesIO | BinaryIO,
@@ -262,6 +266,7 @@ class TestIncludeTargetData:
 
     @staticmethod
     def test_default(
+        *,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
         image: io.BytesIO | BinaryIO,
@@ -292,6 +297,7 @@ class TestIncludeTargetData:
 
     @staticmethod
     def test_top(
+        *,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
         image: io.BytesIO | BinaryIO,
@@ -327,6 +333,7 @@ class TestIncludeTargetData:
 
     @staticmethod
     def test_none(
+        *,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
         image: io.BytesIO | BinaryIO,
@@ -363,6 +370,7 @@ class TestIncludeTargetData:
 
     @staticmethod
     def test_all(
+        *,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
         image: io.BytesIO | BinaryIO,

--- a/tests/test_vws.py
+++ b/tests/test_vws.py
@@ -34,11 +34,11 @@ class TestAddTarget:
     )
     @pytest.mark.parametrize(argnames="active_flag", argvalues=[True, False])
     def test_add_target(
+        *,
         vws_client: VWS,
         image: io.BytesIO | BinaryIO,
         application_metadata: bytes | None,
         cloud_reco_client: CloudRecoService,
-        *,
         active_flag: bool,
     ) -> None:
         """No exception is raised when adding one target."""
@@ -76,6 +76,7 @@ class TestAddTarget:
 
     @staticmethod
     def test_add_two_targets(
+        *,
         vws_client: VWS,
         image: io.BytesIO | BinaryIO,
     ) -> None:
@@ -103,8 +104,8 @@ class TestDefaultRequestTimeout:
         argvalues=[(29, False), (31, True)],
     )
     def test_default_timeout(
-        image: io.BytesIO | BinaryIO,
         *,
+        image: io.BytesIO | BinaryIO,
         response_delay_seconds: int,
         expect_timeout: bool,
     ) -> None:
@@ -169,8 +170,8 @@ class TestCustomRequestTimeout:
         ],
     )
     def test_custom_timeout(
-        image: io.BytesIO | BinaryIO,
         *,
+        image: io.BytesIO | BinaryIO,
         custom_timeout: float | tuple[float, float],
         response_delay_seconds: float,
         expect_timeout: bool,
@@ -251,6 +252,7 @@ class TestListTargets:
 
     @staticmethod
     def test_list_targets(
+        *,
         vws_client: VWS,
         image: io.BytesIO | BinaryIO,
     ) -> None:
@@ -277,6 +279,7 @@ class TestDelete:
 
     @staticmethod
     def test_delete_target(
+        *,
         vws_client: VWS,
         image: io.BytesIO | BinaryIO,
     ) -> None:
@@ -300,6 +303,7 @@ class TestGetTargetSummaryReport:
 
     @staticmethod
     def test_get_target_summary_report(
+        *,
         vws_client: VWS,
         image: io.BytesIO | BinaryIO,
     ) -> None:
@@ -398,6 +402,7 @@ class TestGetTargetRecord:
 
     @staticmethod
     def test_get_target_record(
+        *,
         vws_client: VWS,
         image: io.BytesIO | BinaryIO,
     ) -> None:
@@ -444,6 +449,7 @@ class TestGetTargetRecord:
 
     @staticmethod
     def test_get_failed(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -467,6 +473,7 @@ class TestWaitForTargetProcessed:
 
     @staticmethod
     def test_wait_for_target_processed(
+        *,
         vws_client: VWS,
         image: io.BytesIO | BinaryIO,
     ) -> None:
@@ -628,6 +635,7 @@ class TestGetDuplicateTargets:
 
     @staticmethod
     def test_get_duplicate_targets(
+        *,
         vws_client: VWS,
         image: io.BytesIO | BinaryIO,
     ) -> None:
@@ -658,6 +666,7 @@ class TestUpdateTarget:
 
     @staticmethod
     def test_update_target(
+        *,
         vws_client: VWS,
         image: io.BytesIO | BinaryIO,
         different_high_quality_image: io.BytesIO,
@@ -717,6 +726,7 @@ class TestUpdateTarget:
 
     @staticmethod
     def test_no_fields_given(
+        *,
         vws_client: VWS,
         image: io.BytesIO | BinaryIO,
     ) -> None:
@@ -745,6 +755,7 @@ class TestGenerateVumarkInstance:
         ],
     )
     def test_generate_vumark_instance(
+        *,
         vumark_service_client: VuMarkService,
         vumark_target_id: str,
         accept: VuMarkAccept,

--- a/tests/test_vws_exceptions.py
+++ b/tests/test_vws_exceptions.py
@@ -41,6 +41,7 @@ from vws.vumark_accept import VuMarkAccept
 
 
 def test_image_too_large(
+    *,
     vws_client: VWS,
     png_too_large: io.BytesIO | io.BufferedRandom,
 ) -> None:
@@ -75,7 +76,11 @@ def test_invalid_given_id(vws_client: VWS) -> None:
     assert exc.value.target_id == target_id
 
 
-def test_add_bad_name(vws_client: VWS, high_quality_image: io.BytesIO) -> None:
+def test_add_bad_name(
+    *,
+    vws_client: VWS,
+    high_quality_image: io.BytesIO,
+) -> None:
     """
     When a name with a bad character is given, a ``ServerError``
     exception
@@ -143,6 +148,7 @@ def test_bad_image(vws_client: VWS) -> None:
 
 
 def test_target_name_exist(
+    *,
     vws_client: VWS,
     high_quality_image: io.BytesIO,
 ) -> None:
@@ -201,6 +207,7 @@ def test_project_inactive(
 
 
 def test_target_status_processing(
+    *,
     vws_client: VWS,
     high_quality_image: io.BytesIO,
 ) -> None:
@@ -225,6 +232,7 @@ def test_target_status_processing(
 
 
 def test_metadata_too_large(
+    *,
     vws_client: VWS,
     high_quality_image: io.BytesIO,
 ) -> None:
@@ -246,6 +254,7 @@ def test_metadata_too_large(
 
 
 def test_request_time_too_skewed(
+    *,
     vws_client: VWS,
     high_quality_image: io.BytesIO,
 ) -> None:
@@ -316,6 +325,7 @@ def test_authentication_failure(
 
 
 def test_target_status_not_success(
+    *,
     vws_client: VWS,
     high_quality_image: io.BytesIO,
 ) -> None:
@@ -368,6 +378,7 @@ def test_vwsexception_inheritance() -> None:
 
 
 def test_invalid_instance_id(
+    *,
     vumark_service_client: VuMarkService,
     vumark_target_id: str,
 ) -> None:
@@ -423,6 +434,7 @@ def test_invalid_target_type(
 
 
 def test_base_exception(
+    *,
     vws_client: VWS,
     high_quality_image: io.BytesIO,
 ) -> None:


### PR DESCRIPTION
## Summary
- Enforce keyword-only arguments (using `*`) in test functions that accept multiple parameters
- This improves call-site clarity and prevents accidental positional argument errors

## Test plan
- [ ] Verify tests still pass

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only signature changes with no runtime behavior changes outside pytest collection; low risk aside from potential fixture injection/signature mismatch issues.
> 
> **Overview**
> Updates the test suite to enforce **keyword-only parameters** for pytest tests that take multiple fixtures/arguments by inserting `*` into function signatures (including several `@pytest.mark.parametrize` cases).
> 
> This is a signature-only refactor intended to make test call sites clearer and prevent accidental positional-argument misuse; no production/library code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 253bbea6d26ea2050a32dae30b3776739302c5ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->