### PR TITLE
Add @beartype to pytest_collection_modifyitems hook

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,6 +18,7 @@ from sybil.parsers.rest import (
 )
 
 
+@beartype
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     """Apply the beartype decorator to all collected test functions."""
     for item in items:


### PR DESCRIPTION
## Summary
- Add `@beartype` decorator to `pytest_collection_modifyitems` in root `conftest.py`, which was the only non-fixture test helper missing it

## Test plan
- [ ] CI passes with existing tests

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds runtime type checking to a pytest hook; risk is limited to potential new type errors during collection.
> 
> **Overview**
> Adds `@beartype` to the `pytest_collection_modifyitems` hook in `conftest.py`, so the hook itself is runtime type-checked like the rest of the test helpers.
> 
> No behavioral changes beyond enabling beartype validation when pytest invokes this hook during test collection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a99022f2051daf7167bce129b40267ba72981396. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->