### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,6 @@ from doctest import ELLIPSIS
 from pathlib import Path
 
 import pytest
-from beartype import beartype
 from mock_vws import MockVWS
 from mock_vws.database import CloudDatabase
 from sybil import Sybil
@@ -16,14 +15,6 @@ from sybil.parsers.rest import (
     DocTestParser,
     PythonCodeBlockParser,
 )
-
-
-@beartype
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        if isinstance(item, pytest.Function):
-            item.obj = beartype(obj=item.obj)
 
 
 @pytest.fixture(name="make_image_file")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ optional-dependencies.dev = [
     "pyroma==5.0.1",
     "pytest==9.0.3",
     "pytest-asyncio==1.3.0",
+    "pytest-beartype-tests==2026.4.19.1",
     "pytest-cov==7.1.0",
     "pyyaml==6.0.3",
     "ruff==0.15.11",
@@ -88,11 +89,13 @@ optional-dependencies.dev = [
     "vws-test-fixtures==2023.3.5",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
-    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://vws-python.github.io/vws-python/"
 urls.Source = "https://github.com/VWS-Python/vws-python"
+
+[dependency-groups]
+dev = []
 
 [tool.setuptools]
 zip-safe = false
@@ -402,6 +405,3 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[dependency-groups]
-dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ optional-dependencies.dev = [
     "vws-test-fixtures==2023.3.5",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
+    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://vws-python.github.io/vws-python/"
@@ -364,7 +365,6 @@ ignore_names = [
     "HTTPXTransport",
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",
@@ -402,3 +402,6 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[dependency-groups]
+dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ optional-dependencies.dev = [
     "pyroma==5.0.1",
     "pytest==9.0.3",
     "pytest-asyncio==1.3.0",
-    "pytest-beartype-tests==2026.4.19.1",
+    "pytest-beartype-tests",
     "pytest-cov==7.1.0",
     "pyyaml==6.0.3",
     "ruff==0.15.11",
@@ -118,6 +118,7 @@ bdist_wheel.universal = true
 version_scheme = "post-release"
 
 [tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 sources.torch = { index = "pytorch-cpu" }
 sources.torchvision = { index = "pytorch-cpu" }
 index = [ { name = "pytorch-cpu", url = "https://download.pytorch.org/whl/cpu", explicit = true } ]


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` / `@beartype` wiring from conftest where it duplicated the plugin.

The plugin registers via `pytest11` and applies `@beartype` to collected test functions, matching the previous local hook behavior (see the [upstream README](https://github.com/adamtheturtle/pytest-beartype-tests)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to the test configuration and dev dependencies, but could affect CI/test behavior if the plugin differs from the previous hook.
> 
> **Overview**
> Replaces the local `pytest_collection_modifyitems` + `@beartype` wiring in `conftest.py` with the `pytest-beartype-tests` plugin to apply runtime type checking to collected tests.
> 
> Adds `pytest-beartype-tests` to dev dependencies (with a pinned git `uv` source) and cleans up related config (adds an empty `[dependency-groups] dev` entry and removes the obsolete Vulture ignore for `pytest_collection_modifyitems`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95b5a4695bc73defb4aa66bdc4e184b538d35e1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->