### PR TITLE
Bump mypy to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ optional-dependencies.dev = [
     "freezegun==1.5.5",
     "furo==2025.12.19",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.13",
     "pydocstringformatter==0.7.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because this only changes a dev dependency, but the major `mypy` upgrade may surface new type-checking failures in CI/local workflows.
> 
> **Overview**
> Bumps the dev dependency `mypy[faster-cache]` from `1.20.2` to `2.0.0` in `pyproject.toml` to use the latest major mypy release for type checking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df725392015744f577e1cf483875df44f7e97ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->