### PR TITLE
Enable mypy parallel workers in pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,8 +168,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
-          --num-workers=4"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python
+        args: [--command=mypy --num-workers=4]
         language: python
         types_or: [markdown, rst]
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,7 +157,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -168,7 +168,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,8 +168,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python
-        args: [--command=mypy --num-workers=4]
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies:


### PR DESCRIPTION
## Summary
- run the `mypy` pre-push hook with `--num-workers=4` to enable parallel workers
- run `mypy-docs` via doccmd with a command string that also includes `--num-workers=4`

## Test plan
- [x] pre-commit hooks run successfully on commit (including yamlfix)
- [x] `uv run --extra=dev -m mypy --num-workers=4` (executes; currently hits existing mypy internal error in repo)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects local `pre-push` type-checking execution; main impact is potential nondeterminism/perf differences in mypy output.
> 
> **Overview**
> Updates the `pre-push` pre-commit hooks to run `mypy` with `--num-workers=4`, enabling parallel type-checking.
> 
> Also adjusts the `mypy-docs` `doccmd` invocation so the embedded `mypy` command includes the same `--num-workers=4` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d87cce6d3703693764cc923f869fed20596044a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->