### PR TITLE
[codex] Fix doccmd pylint ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ optional-dependencies.dev = [
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",
-    "doccmd==2026.5.6",
+    "doccmd==2026.5.16",
     "freezegun==1.5.5",
     "furo==2025.12.19",
     "interrogate==1.7.0",
@@ -251,7 +251,9 @@ MASTER.unsafe-load-any-extension = false
 "MESSAGES CONTROL".per-file-ignores = [
     "docs/source/conf.py:invalid-name",
     "docs/source/doccmd_*.py:invalid-name",
+    "docs/source/doccmd_*/*.py:invalid-name",
     "doccmd_README_rst_*.py:invalid-name",
+    "doccmd_*/*.py:invalid-name",
 ]
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.


### PR DESCRIPTION
Updates `doccmd` to 2026.5.16 and extends the pylint per-file ignores for generated documentation examples.

The `doccmd` update now writes generated examples inside `doccmd_<hash>/` directories, so the previous flat-file ignore patterns no longer suppressed `invalid-name` for those transient files.

Validated with `doccmd` running `pylint`, the `pylint-docs` prek hook, `pyproject-fmt`, and the repository pre-push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps a dev-only documentation generator and adjusts `pylint` ignore globs to match its new generated-file layout; no runtime code or production dependencies change.
> 
> **Overview**
> Updates the dev dependency `doccmd` to `2026.5.16`.
> 
> Expands `pylint` `per-file-ignores` patterns to also suppress `invalid-name` for generated doc examples that are now written under nested `doccmd_*/*` directories (including under `docs/source/`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4585e0d3b75254327274ded5b1f0c56e5b1250e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->