### PR TITLE
[codex] Add towncrier to release extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ optional-dependencies.dev = [
     "yamlfix==1.19.1",
     "zizmor==1.25.2",
 ]
-optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
+optional-dependencies.release = [ "check-wheel-contents==0.6.3", "towncrier==25.8.0" ]
 urls.Documentation = "https://vws-python.github.io/vws-python/"
 urls.Source = "https://github.com/VWS-Python/vws-python"
 


### PR DESCRIPTION
## Summary

Add `towncrier==25.8.0` to the `release` extra so the release workflow can run:

```bash
uv run --extra=release towncrier build ...
```

The previous towncrier migration added the tool for development/docs builds, but release jobs install only the `release` extra before invoking towncrier.

## Validation

- `uv lock`
- `uv run --no-dev --extra=release towncrier --version`
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change; it only affects what gets installed when using the `release` extra and does not touch runtime code paths.
> 
> **Overview**
> Ensures release environments can run `towncrier` by adding `towncrier==25.8.0` to the `release` optional dependency extra in `pyproject.toml` (alongside `check-wheel-contents`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de47475dff8a8ea9cac8d4ee064f3db37caaff2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->