### PR TITLE
Add test for RequestQuotaReached exception

### DIFF
--- a/src/vws/exceptions/vws_exceptions.py
+++ b/src/vws/exceptions/vws_exceptions.py
@@ -51,9 +51,8 @@ class AuthenticationFailureError(VWSError):
     """
 
 
-# See https://github.com/VWS-Python/vws-python/issues/822.
 @beartype
-class RequestQuotaReachedError(VWSError):  # pragma: no cover
+class RequestQuotaReachedError(VWSError):
     """Exception raised when Vuforia returns a response with a result code
     'RequestQuotaReached'.
     """

--- a/tests/test_vws_exceptions.py
+++ b/tests/test_vws_exceptions.py
@@ -1,6 +1,7 @@
 """Tests for VWS exceptions."""
 
 import io
+import json
 import uuid
 from http import HTTPStatus
 
@@ -39,6 +40,44 @@ from vws.exceptions.vws_exceptions import (
 )
 from vws.response import Response
 from vws.vumark_accept import VuMarkAccept
+
+
+class _RequestQuotaReachedTransport:
+    """Transport that always returns ``RequestQuotaReached``.
+
+    ``vws-python-mock`` does not yet simulate this result code (see
+    https://github.com/VWS-Python/vws-python-mock/issues/53), so tests
+    use a custom transport instead of ``MockVWS``.
+    """
+
+    def close(self) -> None:
+        """Close the transport."""
+
+    def __call__(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        data: bytes,
+        request_timeout: float | tuple[float, float],
+    ) -> Response:
+        """Return a ``RequestQuotaReached`` response."""
+        del method, headers, request_timeout
+        body = {
+            "transaction_id": uuid.uuid4().hex,
+            "result_code": "RequestQuotaReached",
+        }
+        text = json.dumps(body)
+        return Response(
+            text=text,
+            url=url,
+            status_code=HTTPStatus.FORBIDDEN,
+            headers={"Content-Type": "application/json"},
+            request_body=data,
+            tell_position=0,
+            content=text.encode(),
+        )
 
 
 def test_image_too_large(
@@ -106,9 +145,19 @@ def test_add_bad_name(
 
 def test_request_quota_reached() -> None:
     """
-    See https://github.com/VWS-Python/vws-python/issues/822 for writing
-    this test.
+    A ``RequestQuotaReached`` exception is raised when Vuforia reports
+    that the request quota has been reached.
     """
+    vws_client = VWS(
+        server_access_key=uuid.uuid4().hex,
+        server_secret_key=uuid.uuid4().hex,
+        transport=_RequestQuotaReachedTransport(),
+    )
+
+    with pytest.raises(expected_exception=RequestQuotaReachedError) as exc:
+        vws_client.list_targets()
+
+    assert exc.value.response.status_code == HTTPStatus.FORBIDDEN
 
 
 def test_fail(high_quality_image: io.BytesIO) -> None:

--- a/tests/test_vws_exceptions.py
+++ b/tests/test_vws_exceptions.py
@@ -68,7 +68,7 @@ class _RequestQuotaReachedTransport:
             "transaction_id": uuid.uuid4().hex,
             "result_code": "RequestQuotaReached",
         }
-        text = json.dumps(body)
+        text = json.dumps(obj=body)
         return Response(
             text=text,
             url=url,


### PR DESCRIPTION
## Summary
- Implements the stub `test_request_quota_reached` so `RequestQuotaReachedError` is exercised end-to-end through `VWS.list_targets`.
- Uses a custom transport because `vws-python-mock` still does not simulate this result code ([mock#53](https://github.com/VWS-Python/vws-python-mock/issues/53)).
- Removes the `pragma: no cover` on `RequestQuotaReachedError`.

Closes #822.

## Test plan
- [x] `pytest tests/test_vws_exceptions.py::test_request_quota_reached`
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)