### PR TITLE
Fix target_id when base_vws_url has a path prefix

### DIFF
--- a/newsfragments/3091.change.rst
+++ b/newsfragments/3091.change.rst
@@ -1,0 +1,1 @@
+Fix ``target_id`` on target exceptions when ``base_vws_url`` includes a path prefix.

--- a/src/vws/exceptions/vws_exceptions.py
+++ b/src/vws/exceptions/vws_exceptions.py
@@ -14,6 +14,24 @@ from beartype import beartype
 from vws.exceptions.base_exceptions import VWSError
 
 
+def _target_id_from_url(*, url: str) -> str:
+    """Return the target ID from a VWS response URL.
+
+    Paths may include a custom base URL prefix. The target ID is the
+    path segment after ``targets``, ``summary``, or ``duplicates``.
+    """
+    path = urlparse(url=url).path
+    parts = [part for part in path.split(sep="/") if part]
+    for marker in ("targets", "summary", "duplicates"):
+        try:
+            marker_index = parts.index(marker)
+        except ValueError:
+            continue
+        return parts[marker_index + 1]
+    message = f"Could not find a target ID in URL path {path!r}"
+    raise ValueError(message)  # pragma: no cover
+
+
 @beartype
 class UnknownTargetError(VWSError):
     """Exception raised when Vuforia returns a response with a result code
@@ -23,11 +41,7 @@ class UnknownTargetError(VWSError):
     @property
     def target_id(self) -> str:
         """The unknown target ID."""
-        path = urlparse(url=self.response.url).path
-        # Every HTTP path which can raise this error has the target ID as the
-        # second path segment, e.g. `/something/{target_id}` or
-        # `/something/{target_id}/more`.
-        return path.split(sep="/")[2]
+        return _target_id_from_url(url=self.response.url)
 
 
 @beartype
@@ -68,11 +82,7 @@ class TargetStatusProcessingError(VWSError):
     @property
     def target_id(self) -> str:
         """The processing target ID."""
-        path = urlparse(url=self.response.url).path
-        # Every HTTP path which can raise this error has the target ID as the
-        # second path segment, e.g. `/something/{target_id}` or
-        # `/something/{target_id}/more`.
-        return path.split(sep="/")[2]
+        return _target_id_from_url(url=self.response.url)
 
 
 # This is not simulated by the mock.
@@ -158,11 +168,7 @@ class TargetStatusNotSuccessError(VWSError):
     @property
     def target_id(self) -> str:
         """The unknown target ID."""
-        path = urlparse(url=self.response.url).path
-        # Every HTTP path which can raise this error has the target ID as the
-        # second path segment, e.g. `/something/{target_id}` or
-        # `/something/{target_id}/more`.
-        return path.split(sep="/")[2]
+        return _target_id_from_url(url=self.response.url)
 
 
 @beartype

--- a/src/vws/exceptions/vws_exceptions.py
+++ b/src/vws/exceptions/vws_exceptions.py
@@ -29,7 +29,7 @@ def _target_id_from_url(*, url: str) -> str:
             continue
         return parts[marker_index + 1]
     message = f"Could not find a target ID in URL path {path!r}"
-    raise ValueError(message)  # pragma: no cover
+    raise ValueError(message)
 
 
 @beartype

--- a/tests/test_vws_exceptions.py
+++ b/tests/test_vws_exceptions.py
@@ -526,3 +526,21 @@ def test_target_id_with_base_url_prefixes(
         content=b"",
     )
     assert exception_type(response=response).target_id == "abc"
+
+
+def test_target_id_missing_from_url() -> None:
+    """A clear error is raised when the response URL has no target ID."""
+    response = Response(
+        text="{}",
+        url="https://example.com/no-target-here",
+        status_code=HTTPStatus.NOT_FOUND,
+        headers={},
+        request_body=None,
+        tell_position=0,
+        content=b"",
+    )
+    with pytest.raises(
+        expected_exception=ValueError,
+        match="Could not find a target ID",
+    ):
+        _ = UnknownTargetError(response=response).target_id

--- a/tests/test_vws_exceptions.py
+++ b/tests/test_vws_exceptions.py
@@ -473,3 +473,56 @@ def test_vwserror_from_result_code() -> None:
 
     assert isinstance(exception, UnknownTargetError)
     assert exception.response is response
+
+
+@pytest.mark.parametrize(
+    argnames=("exception_type", "url"),
+    argvalues=[
+        (UnknownTargetError, "https://vws.vuforia.com/targets/abc"),
+        (UnknownTargetError, "https://example.com/prefix/targets/abc"),
+        (UnknownTargetError, "https://example.com/prefix/summary/abc"),
+        (UnknownTargetError, "https://example.com/prefix/duplicates/abc"),
+        (
+            TargetStatusProcessingError,
+            "https://vws.vuforia.com/targets/abc",
+        ),
+        (
+            TargetStatusProcessingError,
+            "https://example.com/prefix/targets/abc",
+        ),
+        (
+            TargetStatusNotSuccessError,
+            "https://vws.vuforia.com/targets/abc",
+        ),
+        (
+            TargetStatusNotSuccessError,
+            "https://example.com/prefix/targets/abc",
+        ),
+        (
+            TargetStatusNotSuccessError,
+            "https://example.com/prefix/targets/abc/instances",
+        ),
+    ],
+)
+def test_target_id_with_base_url_prefixes(
+    *,
+    exception_type: type[
+        UnknownTargetError
+        | TargetStatusProcessingError
+        | TargetStatusNotSuccessError
+    ],
+    url: str,
+) -> None:
+    """``target_id`` is correct even when ``base_vws_url`` has a path
+    prefix.
+    """
+    response = Response(
+        text="{}",
+        url=url,
+        status_code=HTTPStatus.NOT_FOUND,
+        headers={},
+        request_body=None,
+        tell_position=0,
+        content=b"",
+    )
+    assert exception_type(response=response).target_id == "abc"


### PR DESCRIPTION
## Summary
- Fixes `UnknownTargetError`, `TargetStatusProcessingError`, and `TargetStatusNotSuccessError` so `.target_id` is correct when `base_vws_url` includes a path prefix.
- Centralizes parsing in a shared helper that finds the segment after `targets`, `summary`, or `duplicates`.

Closes #3091.

## Test plan
- [x] Parametrized unit tests for all three exception classes with plain and prefixed URLs
- [x] Existing exception integration tests still pass
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)