### PR TITLE
Retain explicitly provided falsy custom transports

### DIFF
--- a/newsfragments/3092.change.rst
+++ b/newsfragments/3092.change.rst
@@ -1,0 +1,1 @@
+Retain explicitly provided falsy custom transports instead of replacing them with defaults.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -2,6 +2,7 @@ AuthenticationFailure
 BadImage
 ConnectionErrorPossiblyImageTooLarge
 DateRangeError
+Falsy
 ImageTooLarge
 InactiveProject
 JSONDecodeError
@@ -45,6 +46,7 @@ dev
 dict
 docstring
 enum
+falsy
 filename
 foo
 formdata

--- a/src/vws/async_query.py
+++ b/src/vws/async_query.py
@@ -60,7 +60,9 @@ class AsyncCloudRecoService:
         self._client_secret_key = client_secret_key
         self._base_vwq_url = base_vwq_url
         self._request_timeout_seconds = request_timeout_seconds
-        self._transport = transport or AsyncHTTPXTransport()
+        self._transport = (
+            transport if transport is not None else AsyncHTTPXTransport()
+        )
 
     async def aclose(self) -> None:
         """Close the underlying transport if it supports closing."""

--- a/src/vws/async_vumark_service.py
+++ b/src/vws/async_vumark_service.py
@@ -46,7 +46,9 @@ class AsyncVuMarkService:
         self._server_secret_key = server_secret_key
         self._base_vws_url = base_vws_url
         self._request_timeout_seconds = request_timeout_seconds
-        self._transport = transport or AsyncHTTPXTransport()
+        self._transport = (
+            transport if transport is not None else AsyncHTTPXTransport()
+        )
 
     async def aclose(self) -> None:
         """Close the underlying transport if it supports closing."""

--- a/src/vws/async_vws.py
+++ b/src/vws/async_vws.py
@@ -57,7 +57,9 @@ class AsyncVWS:
         self._server_secret_key = server_secret_key
         self._base_vws_url = base_vws_url
         self._request_timeout_seconds = request_timeout_seconds
-        self._transport = transport or AsyncHTTPXTransport()
+        self._transport = (
+            transport if transport is not None else AsyncHTTPXTransport()
+        )
 
     async def aclose(self) -> None:
         """Close the underlying transport if it supports closing."""

--- a/src/vws/query.py
+++ b/src/vws/query.py
@@ -56,7 +56,9 @@ class CloudRecoService:
         self._client_secret_key = client_secret_key
         self._base_vwq_url = base_vwq_url
         self._request_timeout_seconds = request_timeout_seconds
-        self._transport = transport or RequestsTransport()
+        self._transport = (
+            transport if transport is not None else RequestsTransport()
+        )
 
     def query(
         self,

--- a/src/vws/vumark_service.py
+++ b/src/vws/vumark_service.py
@@ -43,7 +43,9 @@ class VuMarkService:
         self._server_secret_key = server_secret_key
         self._base_vws_url = base_vws_url
         self._request_timeout_seconds = request_timeout_seconds
-        self._transport = transport or RequestsTransport()
+        self._transport = (
+            transport if transport is not None else RequestsTransport()
+        )
 
     def generate_vumark_instance(
         self,

--- a/src/vws/vws.py
+++ b/src/vws/vws.py
@@ -56,7 +56,9 @@ class VWS:
         self._server_secret_key = server_secret_key
         self._base_vws_url = base_vws_url
         self._request_timeout_seconds = request_timeout_seconds
-        self._transport = transport or RequestsTransport()
+        self._transport = (
+            transport if transport is not None else RequestsTransport()
+        )
 
     def make_request(
         self,

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -346,14 +346,14 @@ def test_falsy_sync_transport_is_retained(
         server_secret_key=secret_key,
         transport=transport,
     ).list_targets()
-    assert targets == []
+    assert not targets
 
     query_results = CloudRecoService(
         client_access_key=access_key,
         client_secret_key=secret_key,
         transport=transport,
     ).query(image=high_quality_image)
-    assert query_results == []
+    assert not query_results
 
     vumark_bytes = VuMarkService(
         server_access_key=access_key,
@@ -381,14 +381,14 @@ async def test_falsy_async_transport_is_retained(
         server_secret_key=secret_key,
         transport=transport,
     ) as vws_client:
-        assert await vws_client.list_targets() == []
+        assert not await vws_client.list_targets()
 
     async with AsyncCloudRecoService(
         client_access_key=access_key,
         client_secret_key=secret_key,
         transport=transport,
     ) as cloud_reco_client:
-        assert await cloud_reco_client.query(image=high_quality_image) == []
+        assert not await cloud_reco_client.query(image=high_quality_image)
 
     async with AsyncVuMarkService(
         server_access_key=access_key,

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,13 +1,24 @@
 """Tests for HTTP transport implementations."""
 
+import io
+import uuid
 from http import HTTPStatus
 
 import httpx
 import pytest
 import respx
 
+from vws import (
+    VWS,
+    AsyncCloudRecoService,
+    AsyncVuMarkService,
+    AsyncVWS,
+    CloudRecoService,
+    VuMarkService,
+)
 from vws.response import Response
 from vws.transports import AsyncHTTPXTransport, HTTPXTransport
+from vws.vumark_accept import VuMarkAccept
 
 
 class TestHTTPXTransport:
@@ -206,3 +217,193 @@ class TestAsyncHTTPXTransport:
         assert route.called
         assert isinstance(response, Response)
         assert response.status_code == HTTPStatus.OK
+
+
+class _FalsyTransport:
+    """A sync transport that is falsy but protocol-conforming."""
+
+    def __bool__(self) -> bool:
+        """Return ``False`` so truthiness checks would skip this
+        transport.
+        """
+        return False
+
+    def close(self) -> None:
+        """Close the transport."""
+
+    def __call__(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        data: bytes,
+        request_timeout: float | tuple[float, float],
+    ) -> Response:
+        """Return a successful API response for the requested URL."""
+        del method, headers, request_timeout
+        if url.endswith("/query"):
+            body = '{"result_code":"Success","results":[]}'
+            return Response(
+                text=body,
+                url=url,
+                status_code=HTTPStatus.OK,
+                headers={},
+                request_body=data,
+                tell_position=0,
+                content=body.encode(),
+            )
+        if "/instances" in url:
+            content = b"vumark-bytes"
+            return Response(
+                text="",
+                url=url,
+                status_code=HTTPStatus.OK,
+                headers={},
+                request_body=data,
+                tell_position=0,
+                content=content,
+            )
+        body = '{"result_code":"Success","results":[]}'
+        return Response(
+            text=body,
+            url=url,
+            status_code=HTTPStatus.OK,
+            headers={},
+            request_body=data,
+            tell_position=0,
+            content=body.encode(),
+        )
+
+
+class _FalsyAsyncTransport:
+    """An async transport that is falsy but protocol-conforming."""
+
+    def __bool__(self) -> bool:
+        """Return ``False`` so truthiness checks would skip this
+        transport.
+        """
+        return False
+
+    async def aclose(self) -> None:
+        """Close the transport."""
+
+    async def __call__(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        data: bytes,
+        request_timeout: float | tuple[float, float],
+    ) -> Response:
+        """Return a successful API response for the requested URL."""
+        del method, headers, request_timeout
+        if url.endswith("/query"):
+            body = '{"result_code":"Success","results":[]}'
+            return Response(
+                text=body,
+                url=url,
+                status_code=HTTPStatus.OK,
+                headers={},
+                request_body=data,
+                tell_position=0,
+                content=body.encode(),
+            )
+        if "/instances" in url:
+            content = b"vumark-bytes"
+            return Response(
+                text="",
+                url=url,
+                status_code=HTTPStatus.OK,
+                headers={},
+                request_body=data,
+                tell_position=0,
+                content=content,
+            )
+        body = '{"result_code":"Success","results":[]}'
+        return Response(
+            text=body,
+            url=url,
+            status_code=HTTPStatus.OK,
+            headers={},
+            request_body=data,
+            tell_position=0,
+            content=body.encode(),
+        )
+
+
+def test_falsy_sync_transport_is_retained(
+    high_quality_image: io.BytesIO,
+) -> None:
+    """Falsy custom sync transports are not replaced by the default."""
+    access_key = uuid.uuid4().hex
+    secret_key = uuid.uuid4().hex
+    transport = _FalsyTransport()
+
+    assert (
+        VWS(
+            server_access_key=access_key,
+            server_secret_key=secret_key,
+            transport=transport,
+        ).list_targets()
+        == []
+    )
+    assert (
+        CloudRecoService(
+            client_access_key=access_key,
+            client_secret_key=secret_key,
+            transport=transport,
+        ).query(image=high_quality_image)
+        == []
+    )
+    assert (
+        VuMarkService(
+            server_access_key=access_key,
+            server_secret_key=secret_key,
+            transport=transport,
+        ).generate_vumark_instance(
+            target_id="target",
+            instance_id="instance",
+            accept=VuMarkAccept.PNG,
+        )
+        == b"vumark-bytes"
+    )
+
+
+@pytest.mark.asyncio
+async def test_falsy_async_transport_is_retained(
+    high_quality_image: io.BytesIO,
+) -> None:
+    """Falsy custom async transports are not replaced by the default."""
+    access_key = uuid.uuid4().hex
+    secret_key = uuid.uuid4().hex
+    transport = _FalsyAsyncTransport()
+
+    async with AsyncVWS(
+        server_access_key=access_key,
+        server_secret_key=secret_key,
+        transport=transport,
+    ) as vws_client:
+        assert await vws_client.list_targets() == []
+
+    async with AsyncCloudRecoService(
+        client_access_key=access_key,
+        client_secret_key=secret_key,
+        transport=transport,
+    ) as cloud_reco_client:
+        assert await cloud_reco_client.query(image=high_quality_image) == []
+
+    async with AsyncVuMarkService(
+        server_access_key=access_key,
+        server_secret_key=secret_key,
+        transport=transport,
+    ) as vumark_client:
+        assert (
+            await vumark_client.generate_vumark_instance(
+                target_id="target",
+                instance_id="instance",
+                accept=VuMarkAccept.PNG,
+            )
+            == b"vumark-bytes"
+        )

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -341,34 +341,30 @@ def test_falsy_sync_transport_is_retained(
     secret_key = uuid.uuid4().hex
     transport = _FalsyTransport()
 
-    assert (
-        VWS(
-            server_access_key=access_key,
-            server_secret_key=secret_key,
-            transport=transport,
-        ).list_targets()
-        == []
+    targets = VWS(
+        server_access_key=access_key,
+        server_secret_key=secret_key,
+        transport=transport,
+    ).list_targets()
+    assert targets == []
+
+    query_results = CloudRecoService(
+        client_access_key=access_key,
+        client_secret_key=secret_key,
+        transport=transport,
+    ).query(image=high_quality_image)
+    assert query_results == []
+
+    vumark_bytes = VuMarkService(
+        server_access_key=access_key,
+        server_secret_key=secret_key,
+        transport=transport,
+    ).generate_vumark_instance(
+        target_id="target",
+        instance_id="instance",
+        accept=VuMarkAccept.PNG,
     )
-    assert (
-        CloudRecoService(
-            client_access_key=access_key,
-            client_secret_key=secret_key,
-            transport=transport,
-        ).query(image=high_quality_image)
-        == []
-    )
-    assert (
-        VuMarkService(
-            server_access_key=access_key,
-            server_secret_key=secret_key,
-            transport=transport,
-        ).generate_vumark_instance(
-            target_id="target",
-            instance_id="instance",
-            accept=VuMarkAccept.PNG,
-        )
-        == b"vumark-bytes"
-    )
+    assert vumark_bytes == b"vumark-bytes"
 
 
 @pytest.mark.asyncio

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -340,6 +340,7 @@ def test_falsy_sync_transport_is_retained(
     access_key = uuid.uuid4().hex
     secret_key = uuid.uuid4().hex
     transport = _FalsyTransport()
+    assert not transport
 
     targets = VWS(
         server_access_key=access_key,
@@ -375,6 +376,7 @@ async def test_falsy_async_transport_is_retained(
     access_key = uuid.uuid4().hex
     secret_key = uuid.uuid4().hex
     transport = _FalsyAsyncTransport()
+    assert not transport
 
     async with AsyncVWS(
         server_access_key=access_key,


### PR DESCRIPTION
## Summary
- Fixes all six clients so only `None` selects the default transport (`transport if transport is not None else ...`).
- Prevents falsy but valid custom transports from being silently replaced.
- Adds sync and async tests covering every affected client constructor.

Closes #3092.

## Test plan
- [x] `pytest tests/test_transports.py::test_falsy_*`
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)