### PR TITLE
Handle non-JSON Cloud Query error responses

### DIFF
--- a/newsfragments/3093.change.rst
+++ b/newsfragments/3093.change.rst
@@ -1,0 +1,1 @@
+Raise a response-carrying ``CloudRecoError`` when Cloud Query returns a documented empty or non-JSON 4xx response instead of leaking ``JSONDecodeError``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,16 +80,11 @@ optional-dependencies.dev = [
     "sphinxcontrib-towncrier==0.5.0a0",
     "strict-kwargs==2026.7.24",
     "sybil==10.1.0",
-    # Listed explicitly (despite being transitive via vws-python-mock) so that
-    # [tool.uv.sources] can redirect to the CPU-only PyTorch index.
-    # See: https://vws-python.github.io/vws-python-mock/installation.html#faster-installation
-    "torch>=2.5.1",
-    "torchvision>=0.20.1",
     "towncrier==25.8.0",
     "ty==0.0.65",
     "types-requests==2.33.0.20260712",
     "vulture==2.16",
-    "vws-python-mock==2026.8.4",
+    "vws-python-mock==2026.8.4.1",
     "vws-test-fixtures==2023.3.5",
     "yamlfix==1.19.1",
     "zizmor==1.28.0",
@@ -117,11 +112,6 @@ zip-safe = false
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
-
-[tool.uv]
-sources.torch = { index = "pytorch-cpu" }
-sources.torchvision = { index = "pytorch-cpu" }
-index = [ { name = "pytorch-cpu", url = "https://download.pytorch.org/whl/cpu", explicit = true } ]
 
 [tool.ruff]
 line-length = 79
@@ -317,13 +307,6 @@ ignore = [
 ]
 
 [tool.deptry]
-# torch and torchvision are listed explicitly in dev deps to allow
-# [tool.uv.sources] to redirect them to the CPU-only PyTorch index,
-# but they are not directly imported in the vws-python source code.
-per_rule_ignores.DEP002 = [
-    "torch",
-    "torchvision",
-]
 optional_dependencies_dev_groups = [
     "dev",
     "release",

--- a/src/vws/async_query.py
+++ b/src/vws/async_query.py
@@ -122,6 +122,8 @@ class AsyncCloudRecoService:
                 error with Vuforia's servers.
             ~vws.exceptions.base_exceptions.CloudRecoError: Vuforia returned
                 a client error without a recognized JSON body.
+            json.JSONDecodeError: Vuforia returned a successful response with
+                an invalid JSON body.
 
         Returns:
             An ordered list of target details of matching

--- a/src/vws/async_query.py
+++ b/src/vws/async_query.py
@@ -12,6 +12,7 @@ from vws_auth_tools import authorization_header, rfc_1123_date
 
 from vws._image_utils import ImageType as _ImageType
 from vws._image_utils import get_image_data as _get_image_data
+from vws.exceptions.base_exceptions import CloudRecoError
 from vws.exceptions.cloud_reco_exceptions import (
     AuthenticationFailureError,
     BadImageError,
@@ -119,6 +120,8 @@ class AsyncCloudRecoService:
                 given image is too large.
             ~vws.exceptions.custom_exceptions.ServerError: There is an
                 error with Vuforia's servers.
+            ~vws.exceptions.base_exceptions.CloudRecoError: Vuforia returned
+                a client error without a recognized JSON body.
 
         Returns:
             An ordered list of target details of matching
@@ -186,7 +189,23 @@ class AsyncCloudRecoService:
         ):  # pragma: no cover
             raise ServerError(response=response)
 
-        result_code = json.loads(s=response.text)["result_code"]
+        content_type = {
+            key.lower(): value for key, value in response.headers.items()
+        }.get("content-type", "")
+        if (
+            response.status_code >= HTTPStatus.BAD_REQUEST
+            and not content_type.lower().startswith("application/json")
+        ):
+            raise CloudRecoError(response=response)
+
+        try:
+            response_body = json.loads(s=response.text)
+        except json.JSONDecodeError as exc:
+            if response.status_code >= HTTPStatus.BAD_REQUEST:
+                raise CloudRecoError(response=response) from exc
+            raise
+
+        result_code = response_body["result_code"]
         if result_code != "Success":
             exception = {
                 "AuthenticationFailure": (AuthenticationFailureError),
@@ -196,9 +215,7 @@ class AsyncCloudRecoService:
             }[result_code]
             raise exception(response=response)
 
-        result_list = list(
-            json.loads(s=response.text)["results"],
-        )
+        result_list = list(response_body["results"])
         return [
             QueryResult.from_response_dict(response_dict=item)
             for item in result_list

--- a/src/vws/query.py
+++ b/src/vws/query.py
@@ -104,6 +104,8 @@ class CloudRecoService:
                 error with Vuforia's servers.
             ~vws.exceptions.base_exceptions.CloudRecoError: Vuforia returned
                 a client error without a recognized JSON body.
+            json.JSONDecodeError: Vuforia returned a successful response with
+                an invalid JSON body.
 
         Returns:
             An ordered list of target details of matching targets.

--- a/src/vws/query.py
+++ b/src/vws/query.py
@@ -10,6 +10,7 @@ from vws_auth_tools import authorization_header, rfc_1123_date
 
 from vws._image_utils import ImageType as _ImageType
 from vws._image_utils import get_image_data as _get_image_data
+from vws.exceptions.base_exceptions import CloudRecoError
 from vws.exceptions.cloud_reco_exceptions import (
     AuthenticationFailureError,
     BadImageError,
@@ -101,6 +102,8 @@ class CloudRecoService:
                 given image is too large.
             ~vws.exceptions.custom_exceptions.ServerError: There is an
                 error with Vuforia's servers.
+            ~vws.exceptions.base_exceptions.CloudRecoError: Vuforia returned
+                a client error without a recognized JSON body.
 
         Returns:
             An ordered list of target details of matching targets.
@@ -156,7 +159,23 @@ class CloudRecoService:
         ):  # pragma: no cover
             raise ServerError(response=response)
 
-        result_code = json.loads(s=response.text)["result_code"]
+        content_type = {
+            key.lower(): value for key, value in response.headers.items()
+        }.get("content-type", "")
+        if (
+            response.status_code >= HTTPStatus.BAD_REQUEST
+            and not content_type.lower().startswith("application/json")
+        ):
+            raise CloudRecoError(response=response)
+
+        try:
+            response_body = json.loads(s=response.text)
+        except json.JSONDecodeError as exc:
+            if response.status_code >= HTTPStatus.BAD_REQUEST:
+                raise CloudRecoError(response=response) from exc
+            raise
+
+        result_code = response_body["result_code"]
         if result_code != "Success":
             exception = {
                 "AuthenticationFailure": AuthenticationFailureError,
@@ -166,7 +185,7 @@ class CloudRecoService:
             }[result_code]
             raise exception(response=response)
 
-        result_list = list(json.loads(s=response.text)["results"])
+        result_list = list(response_body["results"])
         return [
             QueryResult.from_response_dict(response_dict=item)
             for item in result_list

--- a/tests/test_async_cloud_reco_exceptions.py
+++ b/tests/test_async_cloud_reco_exceptions.py
@@ -7,11 +7,12 @@ import uuid
 from http import HTTPStatus
 
 import pytest
-from mock_vws import MockVWS
+from mock_vws import CloudQueryFailureResponse, MockVWS
 from mock_vws.database import CloudDatabase
 from mock_vws.states import States
 
 from vws import AsyncCloudRecoService
+from vws.exceptions.base_exceptions import CloudRecoError
 from vws.exceptions.cloud_reco_exceptions import (
     AuthenticationFailureError,
     InactiveProjectError,
@@ -118,3 +119,52 @@ async def test_inactive_project(
         response = exc.value.response
         assert response.status_code == HTTPStatus.FORBIDDEN
         assert response.tell_position != 0
+
+
+@pytest.mark.parametrize(
+    argnames=("body", "headers"),
+    argvalues=[
+        ("", {"X-Query-Failure": "empty"}),
+        (
+            "Arbitrary upstream failure",
+            {
+                "Content-Type": "application/json",
+                "X-Query-Failure": "text",
+            },
+        ),
+    ],
+    ids=["empty", "arbitrary-text"],
+)
+@pytest.mark.asyncio
+async def test_non_json_client_error(
+    *,
+    high_quality_image: io.BytesIO,
+    body: str,
+    headers: dict[str, str],
+) -> None:
+    """Non-JSON 4xx responses raise a response-carrying error."""
+    database = CloudDatabase()
+    failure_response = CloudQueryFailureResponse(
+        status_code=HTTPStatus.BAD_REQUEST,
+        headers=headers,
+        body=body,
+    )
+    cloud_reco_client = AsyncCloudRecoService(
+        client_access_key=database.client_access_key,
+        client_secret_key=database.client_secret_key,
+    )
+
+    with MockVWS(cloud_query_failure_response=failure_response) as mock:
+        mock.add_cloud_database(cloud_database=database)
+        with pytest.raises(expected_exception=CloudRecoError) as exc:
+            await cloud_reco_client.query(image=high_quality_image)
+
+    response = exc.value.response
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.text == body
+    assert response.content == body.encode()
+    response_headers = {
+        key.lower(): value for key, value in response.headers.items()
+    }
+    assert response_headers["x-query-failure"] == headers["X-Query-Failure"]
+    assert response.request_body

--- a/tests/test_async_cloud_reco_exceptions.py
+++ b/tests/test_async_cloud_reco_exceptions.py
@@ -3,6 +3,7 @@ AsyncCloudRecoService.
 """
 
 import io  # noqa: TC003
+import json
 import uuid
 from http import HTTPStatus
 
@@ -168,3 +169,26 @@ async def test_non_json_client_error(
     }
     assert response_headers["x-query-failure"] == headers["X-Query-Failure"]
     assert response.request_body
+
+
+@pytest.mark.asyncio
+async def test_non_json_success_response(
+    *,
+    high_quality_image: io.BytesIO,
+) -> None:
+    """Malformed successful responses retain the JSON parsing error."""
+    database = CloudDatabase()
+    failure_response = CloudQueryFailureResponse(
+        status_code=HTTPStatus.OK,
+        headers={"Content-Type": "application/json"},
+        body="Not JSON",
+    )
+    cloud_reco_client = AsyncCloudRecoService(
+        client_access_key=database.client_access_key,
+        client_secret_key=database.client_secret_key,
+    )
+
+    with MockVWS(cloud_query_failure_response=failure_response) as mock:
+        mock.add_cloud_database(cloud_database=database)
+        with pytest.raises(expected_exception=json.JSONDecodeError):
+            await cloud_reco_client.query(image=high_quality_image)

--- a/tests/test_cloud_reco_exceptions.py
+++ b/tests/test_cloud_reco_exceptions.py
@@ -5,7 +5,7 @@ import uuid
 from http import HTTPStatus
 
 import pytest
-from mock_vws import MockVWS
+from mock_vws import CloudQueryFailureResponse, MockVWS
 from mock_vws.database import CloudDatabase
 from mock_vws.states import States
 
@@ -126,3 +126,51 @@ def test_inactive_project(
         # We need one test which checks tell position
         # and so we choose this one almost at random.
         assert response.tell_position != 0
+
+
+@pytest.mark.parametrize(
+    argnames=("body", "headers"),
+    argvalues=[
+        ("", {"X-Query-Failure": "empty"}),
+        (
+            "Arbitrary upstream failure",
+            {
+                "Content-Type": "application/json",
+                "X-Query-Failure": "text",
+            },
+        ),
+    ],
+    ids=["empty", "arbitrary-text"],
+)
+def test_non_json_client_error(
+    *,
+    high_quality_image: io.BytesIO,
+    body: str,
+    headers: dict[str, str],
+) -> None:
+    """Non-JSON 4xx responses raise a response-carrying error."""
+    database = CloudDatabase()
+    failure_response = CloudQueryFailureResponse(
+        status_code=HTTPStatus.BAD_REQUEST,
+        headers=headers,
+        body=body,
+    )
+    cloud_reco_client = CloudRecoService(
+        client_access_key=database.client_access_key,
+        client_secret_key=database.client_secret_key,
+    )
+
+    with MockVWS(cloud_query_failure_response=failure_response) as mock:
+        mock.add_cloud_database(cloud_database=database)
+        with pytest.raises(expected_exception=CloudRecoError) as exc:
+            cloud_reco_client.query(image=high_quality_image)
+
+    response = exc.value.response
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.text == body
+    assert response.content == body.encode()
+    response_headers = {
+        key.lower(): value for key, value in response.headers.items()
+    }
+    assert response_headers["x-query-failure"] == headers["X-Query-Failure"]
+    assert response.request_body

--- a/tests/test_cloud_reco_exceptions.py
+++ b/tests/test_cloud_reco_exceptions.py
@@ -1,6 +1,7 @@
 """Tests for exceptions raised when using the CloudRecoService."""
 
 import io  # noqa: TC003
+import json
 import uuid
 from http import HTTPStatus
 
@@ -174,3 +175,25 @@ def test_non_json_client_error(
     }
     assert response_headers["x-query-failure"] == headers["X-Query-Failure"]
     assert response.request_body
+
+
+def test_non_json_success_response(
+    *,
+    high_quality_image: io.BytesIO,
+) -> None:
+    """Malformed successful responses retain the JSON parsing error."""
+    database = CloudDatabase()
+    failure_response = CloudQueryFailureResponse(
+        status_code=HTTPStatus.OK,
+        headers={"Content-Type": "application/json"},
+        body="Not JSON",
+    )
+    cloud_reco_client = CloudRecoService(
+        client_access_key=database.client_access_key,
+        client_secret_key=database.client_secret_key,
+    )
+
+    with MockVWS(cloud_query_failure_response=failure_response) as mock:
+        mock.add_cloud_database(cloud_database=database)
+        with pytest.raises(expected_exception=json.JSONDecodeError):
+            cloud_reco_client.query(image=high_quality_image)


### PR DESCRIPTION
## Summary

- raise a response-carrying `CloudRecoError` for documented empty or non-JSON Cloud Query 4xx responses
- cover both sync and async clients using the new forced-failure support in `vws-python-mock==2026.8.4.1`
- remove the obsolete direct PyTorch development dependencies now that the mock uses OpenCV

The mock support was merged in [vws-python-mock#3315](https://github.com/VWS-Python/vws-python-mock/pull/3315) and released by [workflow run 30913240037](https://github.com/VWS-Python/vws-python-mock/actions/runs/30913240037).

## Validation

- `pytest`: 325 passed with 100% coverage
- all pre-commit and manual hooks
- all pre-push hooks, including mypy, pyright, pyrefly, ty, and package checks

Closes #3093

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling change in Cloud Query with matching tests; dependency cleanup only affects dev/test installs.
> 
> **Overview**
> Cloud Query **sync and async** clients now treat documented **4xx responses with empty or non-JSON bodies** as **`CloudRecoError`** (with the HTTP response attached) instead of surfacing **`JSONDecodeError`**. Parsing is centralized in a single **`response_body`** load; **successful responses with invalid JSON** still raise **`JSONDecodeError`**.
> 
> Dev tooling drops explicit **PyTorch/torchvision** pins and the **CPU PyTorch uv index**, and bumps **`vws-python-mock`** to **2026.8.4.1** so tests can force Cloud Query failures via **`CloudQueryFailureResponse`**. New tests cover empty and arbitrary-text 4xx bodies plus malformed 200 responses for both clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8344edef77c55c928db74650707b5291b44323b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->