### PR TITLE
Sync Vale styles when .vale.ini changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -295,12 +295,15 @@ repos:
       # directory.
       # Vale needs ``rst2html`` from Docutils on the ``PATH`` to parse
       # reStructuredText.
+      # ``vale sync`` also runs when ``.vale.ini`` changes, so a package
+      # bump takes effect without waiting for the next reStructuredText
+      # change.
       - id: vale-sync
         name: vale sync
         entry: uv run --extra=dev vale sync
         language: python
         pass_filenames: false
-        types_or: [rst]
+        files: (\.rst$|^\.vale\.ini$)
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]


### PR DESCRIPTION
Follow-up to #3125.

The `vale sync` hook was gated on `types_or: [rst]`, so a commit that only touched `.vale.ini` (bumping the pinned ClearProse package, say) never triggered a sync. The gitignored `styles/` tree could stay on the old rules until the next reStructuredText change, meaning local Vale runs applied rules that did not match the committed config.

The hook now matches `.rst` files and `.vale.ini`, so a package bump takes effect straight away.

Verified locally: `prek run vale-sync --files .vale.ini` runs the hook rather than skipping it, and it still runs for `.rst` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pre-commit hook selection only; no runtime app or security impact.
> 
> **Overview**
> The **`vale-sync`** pre-commit hook no longer relies only on `types_or: [rst]`. It now uses a **`files`** regex so it runs when **`.rst`** files or **`.vale.ini`** are in the commit.
> 
> That way a **ClearProse** (or other package) bump in **`.vale.ini`** refreshes the gitignored **`styles/`** tree immediately, instead of leaving local Vale on stale rules until the next RST edit. Comments in **`.pre-commit-config.yaml`** document this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 489724bff1f384fc3525b5a04e41afd6ba285e8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->