### PR TITLE
Lint Markdown prose with Vale

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -289,7 +289,7 @@ repos:
         stages: [pre-commit]
 
       # Vale enforces prose style rules, such as banning em dashes, in
-      # reStructuredText files.
+      # reStructuredText and Markdown files.
       # The rules come from the ``ClearProse`` package pinned in ``.vale.ini``,
       # which ``vale sync`` downloads into the (gitignored) ``styles``
       # directory.
@@ -303,7 +303,7 @@ repos:
         entry: uv run --extra=dev vale sync
         language: python
         pass_filenames: false
-        files: (\.rst$|^\.vale\.ini$)
+        files: (\.(rst|md)$|^\.vale\.ini$)
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
@@ -312,7 +312,7 @@ repos:
         name: vale
         entry: uv run --extra=dev vale
         language: python
-        types_or: [rst]
+        types_or: [rst, markdown]
         require_serial: true
         additional_dependencies:
           - *uv_version

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,5 +3,5 @@ MinAlertLevel = error
 
 Packages = https://github.com/adamtheturtle/vale-style-clear-prose/releases/download/v1.1.0/ClearProse.zip
 
-[*.rst]
+[*.{rst,md}]
 BasedOnStyles = ClearProse


### PR DESCRIPTION
Follow-up to the change that banned em dashes in reStructuredText.

`.rst` was the wrong boundary: it came from the shape of the original vws-python change, not from where our prose lives. Markdown is prose too, and nothing was checking it. Vale now lints both (`[*.{rst,md}]`), and the `vale` hook gains `markdown` to its `types_or` while `vale sync` re-runs for `.md` changes as well.

No prose changes were needed here; the existing Markdown is already clean. The value is preventive, and it makes the rule consistent across every repository that has this hook.

Verified locally: Vale reports no alerts over the tracked `.rst` and `.md` files, and `prek run` over the changed files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to dev hooks; no runtime, auth, or data paths affected.
> 
> **Overview**
> Extends the existing **ClearProse / Vale** setup so Markdown gets the same prose rules (for example no em dashes) as reStructuredText, instead of only `.rst` files.
> 
> In **`.vale.ini`**, the scope moves from `[*.rst]` to `[*.{rst,md}]`. In **`.pre-commit-config.yaml`**, the `vale` hook now includes `markdown` in `types_or`, and `vale sync` also runs when `.md` files change via an updated `files` pattern. Comments are updated to describe both formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e698d44473c832fb3081becce84eeee15b815b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->