### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.22.9",
+    "beartype==0.23.0rc0",
     "httpx>=0.28.0",
     "requests>=2.32.3",
     "urllib3>=2.2.3",


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Beartype decorates most public API entry points, so an RC pin could change runtime type-check behavior; import-only edits are low risk but touch many modules.
> 
> **Overview**
> Pins **`beartype`** to **`0.23.0rc0`** in `pyproject.toml` (from `>=0.22.9`) so CI can exercise the release candidate against the full test suite; the lockfile is updated to match.
> 
> Across **`src/vws`** and tests, type-only imports that used **`# noqa: TC003`** are moved behind **`if TYPE_CHECKING:`** blocks (e.g. `Response`, `Transport`, `VuMarkAccept`, `io`, `Generator`). Runtime import graphs stay lean for **`@beartype`** while annotations remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02a54b24e5f194b526232eb25098330f617920b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->