### PR TITLE
Map the ProjectHasNoApiAccess result code

### DIFF
--- a/newsfragments/3128.change.rst
+++ b/newsfragments/3128.change.rst
@@ -1,0 +1,1 @@
+Map the ``ProjectHasNoApiAccess`` result code, as spelled in Vuforia's result codes table, to ``ProjectHasNoAPIAccessError``. The previously mapped ``ProjectHasNoAPIAccess`` casing still raises the same exception.

--- a/newsfragments/3128.change.rst
+++ b/newsfragments/3128.change.rst
@@ -1,1 +1,1 @@
-Map the ``ProjectHasNoApiAccess`` result code, as spelled in Vuforia's result codes table, to ``ProjectHasNoAPIAccessError``. The previously mapped ``ProjectHasNoAPIAccess`` casing still raises the same exception.
+Map the ``ProjectHasNoApiAccess`` result code, as spelled in Vuforia's result codes table, to ``ProjectHasNoAPIAccessError``. The previously mapped ``ProjectHasNoAPIAccess`` casing, which Vuforia does not document, is no longer mapped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ optional-dependencies.dev = [
     "types-requests==2.33.0.20260712",
     "vale==3.13.0.0",
     "vulture==2.16",
-    "vws-python-mock==2026.8.4.2",
+    "vws-python-mock==2026.8.14",
     "vws-test-fixtures==2023.3.5",
     "yamlfix==1.19.1",
     "zizmor==1.29.0",

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -14,6 +14,7 @@ MetadataTooLarge
 OopsAnErrorOccurredPossiblyBadName
 OopsAnErrorOccurredPossiblyBadNameError
 ProjectHasNoAPIAccess
+ProjectHasNoApiAccess
 ProjectInactive
 ProjectSuspended
 QuotaExceeded

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -13,7 +13,6 @@ MaxNumResultsOutOfRange
 MetadataTooLarge
 OopsAnErrorOccurredPossiblyBadName
 OopsAnErrorOccurredPossiblyBadNameError
-ProjectHasNoAPIAccess
 ProjectHasNoApiAccess
 ProjectInactive
 ProjectSuspended

--- a/src/vws/exceptions/vws_exceptions.py
+++ b/src/vws/exceptions/vws_exceptions.py
@@ -241,9 +241,6 @@ VWSError.register_exceptions_by_result_code(
         "InvalidTargetType": InvalidTargetTypeError,
         "LicenseCheckFailed": LicenseCheckFailedError,
         "MetadataTooLarge": MetadataTooLargeError,
-        # This casing comes from Vuforia's result codes table.  No real
-        # response with this result code has been observed, with this or any
-        # other casing.
         "ProjectHasNoApiAccess": ProjectHasNoAPIAccessError,
         "ProjectInactive": ProjectInactiveError,
         "ProjectSuspended": ProjectSuspendedError,

--- a/src/vws/exceptions/vws_exceptions.py
+++ b/src/vws/exceptions/vws_exceptions.py
@@ -110,10 +110,6 @@ class ProjectSuspendedError(VWSError):
 class ProjectHasNoAPIAccessError(VWSError):
     """Exception raised when Vuforia returns a response with a result code
     'ProjectHasNoApiAccess'.
-
-    Vuforia's result codes table spells this result code
-    'ProjectHasNoApiAccess', but no real response with either casing has
-    been observed, so 'ProjectHasNoAPIAccess' raises this exception too.
     """
 
 
@@ -245,11 +241,9 @@ VWSError.register_exceptions_by_result_code(
         "InvalidTargetType": InvalidTargetTypeError,
         "LicenseCheckFailed": LicenseCheckFailedError,
         "MetadataTooLarge": MetadataTooLargeError,
-        # Vuforia's result codes table spells this ``ProjectHasNoApiAccess``.
-        # ``ProjectHasNoAPIAccess`` was mapped first, from a hand-written list
-        # rather than an observed response.  No real response with either
-        # casing has been observed, so both are mapped.
-        "ProjectHasNoAPIAccess": ProjectHasNoAPIAccessError,
+        # This casing comes from Vuforia's result codes table.  No real
+        # response with this result code has been observed, with this or any
+        # other casing.
         "ProjectHasNoApiAccess": ProjectHasNoAPIAccessError,
         "ProjectInactive": ProjectInactiveError,
         "ProjectSuspended": ProjectSuspendedError,

--- a/src/vws/exceptions/vws_exceptions.py
+++ b/src/vws/exceptions/vws_exceptions.py
@@ -109,7 +109,11 @@ class ProjectSuspendedError(VWSError):
 @beartype
 class ProjectHasNoAPIAccessError(VWSError):
     """Exception raised when Vuforia returns a response with a result code
-    'ProjectHasNoAPIAccess'.
+    'ProjectHasNoApiAccess'.
+
+    Vuforia's result codes table spells this result code
+    'ProjectHasNoApiAccess', but no real response with either casing has
+    been observed, so 'ProjectHasNoAPIAccess' raises this exception too.
     """
 
 
@@ -241,7 +245,12 @@ VWSError.register_exceptions_by_result_code(
         "InvalidTargetType": InvalidTargetTypeError,
         "LicenseCheckFailed": LicenseCheckFailedError,
         "MetadataTooLarge": MetadataTooLargeError,
+        # Vuforia's result codes table spells this ``ProjectHasNoApiAccess``.
+        # ``ProjectHasNoAPIAccess`` was mapped first, from a hand-written list
+        # rather than an observed response.  No real response with either
+        # casing has been observed, so both are mapped.
         "ProjectHasNoAPIAccess": ProjectHasNoAPIAccessError,
+        "ProjectHasNoApiAccess": ProjectHasNoAPIAccessError,
         "ProjectInactive": ProjectInactiveError,
         "ProjectSuspended": ProjectSuspendedError,
         "QuotaExceeded": QuotaExceededError,

--- a/tests/test_vws_exceptions.py
+++ b/tests/test_vws_exceptions.py
@@ -584,6 +584,35 @@ def test_vwserror_from_result_code() -> None:
 
 
 @pytest.mark.parametrize(
+    argnames="result_code",
+    argvalues=["ProjectHasNoApiAccess", "ProjectHasNoAPIAccess"],
+)
+def test_project_has_no_api_access_casings(result_code: str) -> None:
+    """Both casings of the ``ProjectHasNoApiAccess`` result code map to
+    ``ProjectHasNoAPIAccessError``.
+
+    Vuforia's result codes table uses ``ProjectHasNoApiAccess``, but no
+    real response with either casing has been observed.
+    """
+    response = Response(
+        text=f'{{"result_code":"{result_code}"}}',
+        url="https://example.com/targets",
+        status_code=HTTPStatus.FORBIDDEN,
+        headers={},
+        request_body=None,
+        tell_position=0,
+        content=b"",
+    )
+
+    exception = VWSError.from_result_code(
+        result_code=result_code,
+        response=response,
+    )
+
+    assert isinstance(exception, ProjectHasNoAPIAccessError)
+
+
+@pytest.mark.parametrize(
     argnames=("exception_type", "url"),
     argvalues=[
         (UnknownTargetError, "https://vws.vuforia.com/targets/abc"),

--- a/tests/test_vws_exceptions.py
+++ b/tests/test_vws_exceptions.py
@@ -583,17 +583,11 @@ def test_vwserror_from_result_code() -> None:
     assert exception.response is response
 
 
-@pytest.mark.parametrize(
-    argnames="result_code",
-    argvalues=["ProjectHasNoApiAccess", "ProjectHasNoAPIAccess"],
-)
-def test_project_has_no_api_access_casings(result_code: str) -> None:
-    """Both casings of the ``ProjectHasNoApiAccess`` result code map to
-    ``ProjectHasNoAPIAccessError``.
-
-    Vuforia's result codes table uses ``ProjectHasNoApiAccess``, but no
-    real response with either casing has been observed.
+def test_project_has_no_api_access_casing() -> None:
+    """The ``ProjectHasNoApiAccess`` result code, as spelled in Vuforia's
+    result codes table, maps to ``ProjectHasNoAPIAccessError``.
     """
+    result_code = "ProjectHasNoApiAccess"
     response = Response(
         text=f'{{"result_code":"{result_code}"}}',
         url="https://example.com/targets",


### PR DESCRIPTION
Closes #3128.

Vuforia's [result codes table](https://developer.vuforia.com/library/vuforia-engine/web-api/cloud-targets-web-services-api/) spells this result code `ProjectHasNoApiAccess`, while this package mapped only `ProjectHasNoAPIAccess` — a spelling which traces back to a hand-written list in `vws-python-mock` rather than an observed response. No real response with this result code has been found, with either casing.

- `ProjectHasNoApiAccess` now maps to `ProjectHasNoAPIAccessError`.
- `ProjectHasNoAPIAccess`, which Vuforia does not document, is no longer mapped.
- The `vws-python-mock` pin is bumped to `2026.8.14`, the release which contains the mock-side casing change (VWS-Python/vws-python-mock#3352), so the mock-backed project-state test exercises the documented spelling.

The exception class name is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small registry-key change in exception mapping; only callers depending on the undocumented `ProjectHasNoAPIAccess` string would see different behavior.
> 
> **Overview**
> Aligns VWS result-code handling with Vuforia’s documented spelling **`ProjectHasNoApiAccess`** (lowercase “pi” in “Api”). **`VWSError.from_result_code`** now maps that string to the existing **`ProjectHasNoAPIAccessError`**; the previously mapped **`ProjectHasNoAPIAccess`** key is removed because it is not in Vuforia’s table.
> 
> The exception class name is unchanged; only the docstring and registry key reflect the documented code. A unit test asserts the documented casing maps correctly, and the **`vws-python-mock`** dev dependency is bumped so mock-backed project-state tests use the same spelling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb5e1cab02da6d018ba4a437d37a0bbc0df21fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->